### PR TITLE
Update earthkit-transforms to use latest version of earthkit-data

### DIFF
--- a/ci/environment-ci.yml
+++ b/ci/environment-ci.yml
@@ -17,4 +17,6 @@ dependencies:
 # Additional dependencies
 - nbsphinx
 - pandas-stubs
+# Both of these are required for earthkit-data when installing from conda-forge:
 - array-api-compat
+- multiurl

--- a/ci/environment-ci.yml
+++ b/ci/environment-ci.yml
@@ -17,3 +17,4 @@ dependencies:
 # Additional dependencies
 - nbsphinx
 - pandas-stubs
+- array-api-compat

--- a/earthkit/transforms/aggregate/climatology.py
+++ b/earthkit/transforms/aggregate/climatology.py
@@ -691,6 +691,7 @@ def _anomaly_dataarray(
     groupby_kwargs: dict = {},
     relative: bool = False,
     climatology_how_tag: str = "",
+    how_label: str | None = None,
     **reduce_kwargs,
 ) -> xr.DataArray:
     """
@@ -768,11 +769,15 @@ def _anomaly_dataarray(
 
     anomaly_array = resample(anomaly_array, how="mean", **reduce_kwargs, **groupby_kwargs, dim=time_dim)
 
-    return update_anomaly_array(anomaly_array, dataarray, var_name, name_tag, update_attrs)
+    return update_anomaly_array(
+        anomaly_array, dataarray, var_name, name_tag, update_attrs, how_label=how_label
+    )
 
 
-def update_anomaly_array(anomaly_array, original_array, var_name, name_tag, update_attrs):
-    anomaly_array = anomaly_array.rename(f"{var_name}_{name_tag}")
+def update_anomaly_array(anomaly_array, original_array, var_name, name_tag, update_attrs, how_label=None):
+    if how_label is not None:
+        var_name = f"{var_name}_{how_label}"
+    anomaly_array = anomaly_array.rename(f"{var_name}")
     update_attrs = {**original_array.attrs, **update_attrs}
     if "standard_name" in update_attrs:
         update_attrs["standard_name"] += f"_{name_tag.replace(' ', '_')}"

--- a/earthkit/transforms/aggregate/temporal.py
+++ b/earthkit/transforms/aggregate/temporal.py
@@ -13,10 +13,11 @@ from earthkit.transforms.tools import groupby_time
 
 logger = logging.getLogger(__name__)
 
-
+@tools.time_dim_decorator
 def standardise_time(
     dataarray: xr.Dataset | xr.DataArray,
     target_format: str = "%Y-%m-%d %H:%M:%S",
+    time_dim: str | None = None,
 ) -> xr.Dataset | xr.DataArray:
     """
     Convert time coordinates to a standard format using the Gregorian calendar.
@@ -45,17 +46,17 @@ def standardise_time(
 
     """
     try:
-        source_times = [time_value.strftime(target_format) for time_value in dataarray.time.values]
+        source_times = [time_value.strftime(target_format) for time_value in dataarray[time_dim].values]
     except AttributeError:
         source_times = [
-            pd.to_datetime(time_value).strftime(target_format) for time_value in dataarray.time.values
+            pd.to_datetime(time_value).strftime(target_format) for time_value in dataarray[time_dim].values
         ]
 
     standardised_times = np.array(
         [pd.to_datetime(time_string).to_datetime64() for time_string in source_times]
     )
 
-    dataarray = dataarray.assign_coords({"time": standardised_times})
+    dataarray = dataarray.assign_coords({time_dim: standardised_times})
 
     history = dataarray.attrs.get("history", "")
     history += (

--- a/earthkit/transforms/aggregate/temporal.py
+++ b/earthkit/transforms/aggregate/temporal.py
@@ -13,6 +13,7 @@ from earthkit.transforms.tools import groupby_time
 
 logger = logging.getLogger(__name__)
 
+
 @tools.time_dim_decorator
 def standardise_time(
     dataarray: xr.Dataset | xr.DataArray,

--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,3 @@ dependencies:
 - geopandas
 - rasterio
 - earthkit-data[all]
-- pip
-- pip:
-  - git+https://github.com/ecmwf/multiurl

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
 - xarray
 - geopandas
 - rasterio
-- earthkit-data
+- earthkit-data[all]
 - pip
 - pip:
   - git+https://github.com/ecmwf/multiurl

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,6 @@ dependencies:
 - numpy
 - xarray
 - geopandas
-- rasterio
 - earthkit-data
 - pip
 - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
 - numpy
 - xarray
 - geopandas
+- rasterio
 - earthkit-data
 - pip
 - pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ all = [
   # Additional, heavy, dependencies required by the complete package
   "rasterio"  # Requires GDAL
 ]
+rasterio = [
+  "rasterio"  # Requires GDAL
+]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ name = "earthkit-transforms"
 readme = "README.rst"
 
 [project.optional-dependencies]
-complete = [
+all = [
   # Additional, heavy, dependencies required by the complete package
   "rasterio"  # Requires GDAL
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,15 +16,20 @@ classifiers = [
 dependencies = [
   "xarray>=2022.3.0",
   "numpy>=1.18",
-  "earthkit-data>=0.3.0",
-  "geopandas",
-  "rasterio"
+  "earthkit-data>=0.11.2",
+  "geopandas"
 ]
 description = "Aggregation tools for meteorological and climate data."
 dynamic = ["version"]
 license = {file = "LICENSE"}
 name = "earthkit-transforms"
 readme = "README.rst"
+
+[project.optional-dependencies]
+complete = [
+  # Additional, heavy, dependencies required by the complete package
+  "rasterio"  # Requires GDAL
+]
 
 [tool.coverage.run]
 branch = true

--- a/tests/test_30_spatial.py
+++ b/tests/test_30_spatial.py
@@ -10,7 +10,8 @@ from earthkit.data.testing import earthkit_remote_test_data_file
 from earthkit.transforms.aggregate import spatial
 
 try:
-    import rasterio as _
+    import rasterio  # noqa: F401
+
     rasterio_available = True
 except ImportError:
     rasterio_available = False
@@ -18,7 +19,8 @@ except ImportError:
 # Use caching for speedy repeats
 ek_data.settings.set("cache-policy", "user")
 
-class dummy_class():
+
+class dummy_class:
     def __init__(self):
         self.to_pandas = pd.DataFrame
         self.to_geopandas = pd.DataFrame

--- a/tests/test_30_spatial.py
+++ b/tests/test_30_spatial.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 
 # from earthkit.data.core.temporary import temp_directory
@@ -8,8 +9,19 @@ from earthkit import data as ek_data
 from earthkit.data.testing import earthkit_remote_test_data_file
 from earthkit.transforms.aggregate import spatial
 
+try:
+    import rasterio as _
+    rasterio_available = True
+except ImportError:
+    rasterio_available = False
+
 # Use caching for speedy repeats
 ek_data.settings.set("cache-policy", "user")
+
+class dummy_class():
+    def __init__(self):
+        self.to_pandas = pd.DataFrame
+        self.to_geopandas = pd.DataFrame
 
 
 def get_grid_data():
@@ -18,15 +30,25 @@ def get_grid_data():
 
 
 def get_shape_data():
-    remote_nuts_url = earthkit_remote_test_data_file("test-data", "NUTS_RG_60M_2021_4326_LEVL_0.geojson")
-    return ek_data.from_source("url", remote_nuts_url)
+    if rasterio_available:
+        remote_nuts_url = earthkit_remote_test_data_file("test-data", "NUTS_RG_60M_2021_4326_LEVL_0.geojson")
+        return ek_data.from_source("url", remote_nuts_url)
+    return dummy_class()
 
 
+@pytest.mark.skipif(
+    not rasterio_available,
+    reason="rasterio is not available",
+)
 def test_spatial_mask():
     single_masked_data = spatial.mask(get_grid_data(), get_shape_data())
     assert isinstance(single_masked_data, xr.Dataset)
 
 
+@pytest.mark.skipif(
+    not rasterio_available,
+    reason="rasterio is not available",
+)
 @pytest.mark.parametrize(
     "era5_data, nuts_data, expected_result_type",
     (
@@ -34,7 +56,7 @@ def test_spatial_mask():
         [get_grid_data().to_xarray(), get_shape_data(), xr.Dataset],
         [get_grid_data().to_xarray(), get_shape_data().to_pandas(), xr.Dataset],
         [get_grid_data(), get_shape_data().to_pandas(), xr.Dataset],
-        [get_grid_data().to_xarray().t2m, get_shape_data(), xr.DataArray],
+        [get_grid_data().to_xarray()["2t"], get_shape_data(), xr.DataArray],
     ),
 )
 def test_spatial_masks_with_ek_objects(era5_data, nuts_data, expected_result_type):
@@ -49,16 +71,20 @@ def test_spatial_masks_with_ek_objects(era5_data, nuts_data, expected_result_typ
     (
         [get_grid_data(), xr.Dataset],
         [get_grid_data().to_xarray(), xr.Dataset],
-        [get_grid_data().to_xarray().t2m, xr.DataArray],
+        [get_grid_data().to_xarray()["2t"], xr.DataArray],
     ),
 )
 def test_spatial_reduce_no_geometry(era5_data, expected_result_type):
     reduced_data = spatial.reduce(era5_data)
 
     assert isinstance(reduced_data, expected_result_type)
-    assert list(reduced_data.dims) == ["time"]
+    assert list(reduced_data.dims) == ["forecast_reference_time"]
 
 
+@pytest.mark.skipif(
+    not rasterio_available,
+    reason="rasterio is not available",
+)
 @pytest.mark.parametrize(
     "era5_data, nuts_data, expected_result_type",
     (
@@ -66,16 +92,20 @@ def test_spatial_reduce_no_geometry(era5_data, expected_result_type):
         [get_grid_data().to_xarray(), get_shape_data(), xr.Dataset],
         [get_grid_data().to_xarray(), get_shape_data().to_pandas(), xr.Dataset],
         [get_grid_data(), get_shape_data().to_pandas(), xr.Dataset],
-        [get_grid_data().to_xarray().t2m, get_shape_data(), xr.DataArray],
+        [get_grid_data().to_xarray()["2t"], get_shape_data(), xr.DataArray],
     ),
 )
 def test_spatial_reduce_with_geometry(era5_data, nuts_data, expected_result_type):
     reduced_data = spatial.reduce(era5_data, nuts_data)
     assert isinstance(reduced_data, expected_result_type)
-    assert all([dim in ["time", "index"] for dim in reduced_data.dims])
+    assert all([dim in ["forecast_reference_time", "index"] for dim in reduced_data.dims])
     assert len(reduced_data["index"]) == len(nuts_data)
 
 
+@pytest.mark.skipif(
+    not rasterio_available,
+    reason="rasterio is not available",
+)
 @pytest.mark.parametrize(
     "era5_data, nuts_data, expected_result_type",
     ([get_grid_data().to_xarray(), get_shape_data().to_pandas(), xr.Dataset],),
@@ -83,17 +113,21 @@ def test_spatial_reduce_with_geometry(era5_data, nuts_data, expected_result_type
 def test_spatial_reduce_with_geometry_and_latitude_weights(era5_data, nuts_data, expected_result_type):
     reduced_data = spatial.reduce(era5_data, nuts_data, weights="latitude")
     assert isinstance(reduced_data, expected_result_type)
-    assert all([dim in ["time", "index"] for dim in reduced_data.dims])
+    assert all([dim in ["forecast_reference_time", "index"] for dim in reduced_data.dims])
     assert len(reduced_data["index"]) == len(nuts_data)
 
     # Ensure weights works with an abstract name for latitude
     era5_data = era5_data.rename({"latitude": "elephant"})
     reduced_data = spatial.reduce(era5_data, nuts_data, weights="latitude", lat_key="elephant")
     assert isinstance(reduced_data, expected_result_type)
-    assert all([dim in ["time", "index"] for dim in reduced_data.dims])
+    assert all([dim in ["forecast_reference_time", "index"] for dim in reduced_data.dims])
     assert len(reduced_data["index"]) == len(nuts_data)
 
 
+@pytest.mark.skipif(
+    not rasterio_available,
+    reason="rasterio is not available",
+)
 def test_mask_kwargs():
     era5_data = get_grid_data()
     era5_xr = era5_data.to_xarray()
@@ -103,17 +137,17 @@ def test_mask_kwargs():
     nuts_DK = nuts_gpd[nuts_gpd["CNTR_CODE"] == "DK"]
 
     masked_data = spatial.masks(era5_xr, nuts_DK, all_touched=True)
-    assert len(np.where(~np.isnan(masked_data.t2m.values.flat))[0]) == 3432
+    assert len(np.where(~np.isnan(masked_data["2t"].values.flat))[0]) == 3432
 
     masked_data = spatial.masks(era5_xr, nuts_DK, all_touched=False)
-    assert len(np.where(~np.isnan(masked_data.t2m.values.flat))[0]) == 2448
+    assert len(np.where(~np.isnan(masked_data["2t"].values.flat))[0]) == 2448
 
     reduced_data = spatial.reduce(era5_xr, nuts_DK, all_touched=True)
     reduced_data_nested = spatial.reduce(era5_xr, nuts_DK, mask_kwargs=dict(all_touched=True))
     xr.testing.assert_equal(reduced_data, reduced_data_nested)
-    np.testing.assert_allclose(reduced_data.t2m.mean(), 279.4813)
+    np.testing.assert_allclose(reduced_data["2t"].mean(), 279.4813)
 
     reduced_data_2 = spatial.reduce(era5_xr, nuts_DK, all_touched=False)
     reduced_data_nested_2 = spatial.reduce(era5_xr, nuts_DK, mask_kwargs=dict(all_touched=False))
     xr.testing.assert_equal(reduced_data_2, reduced_data_nested_2)
-    np.testing.assert_allclose(reduced_data_2.t2m.mean(), 279.54733)
+    np.testing.assert_allclose(reduced_data_2["2t"].mean(), 279.54733)

--- a/tests/test_30_temporal.py
+++ b/tests/test_30_temporal.py
@@ -23,37 +23,40 @@ def get_data():
     (
         [get_data(), xr.Dataset],
         [get_data().to_xarray(), xr.Dataset],
-        [get_data().to_xarray().t2m, xr.DataArray],
+        [get_data().to_xarray()["2t"], xr.DataArray],
     ),
 )
 def test_temporal_reduce(in_data, expected_return_type):
     reduced_data = temporal.reduce(in_data, how="mean")
     assert isinstance(reduced_data, expected_return_type)
-    assert "time" not in list(reduced_data.dims)
+    assert "forecast_reference_time" not in list(reduced_data.dims)
     if expected_return_type == xr.DataArray:
-        assert "t2m" == reduced_data.name
+        assert "2t" == reduced_data.name
     else:
-        assert "t2m" in reduced_data
+        assert "2t" in reduced_data
     reduced_data = temporal.reduce(in_data, how="mean", how_label="mean")
     assert isinstance(reduced_data, expected_return_type)
-    assert "time" not in list(reduced_data.dims)
+    assert "forecast_reference_time" not in list(reduced_data.dims)
     if expected_return_type == xr.DataArray:
-        assert "t2m_mean" == reduced_data.name
+        assert "2t_mean" == reduced_data.name
     else:
-        assert "t2m_mean" in reduced_data
+        assert "2t_mean" in reduced_data
 
 
 def test_standardise_time_basic():
     data = get_data().to_xarray()
-    original_time = data.time
+    original_time = data.forecast_reference_time
     data_standardised = temporal.standardise_time(data)
-    np.testing.assert_array_equal(original_time.values, data_standardised.time.values)
+    np.testing.assert_array_equal(original_time.values, data_standardised.forecast_reference_time.values)
 
 
 def test_standardise_time_monthly():
     data = get_data().to_xarray()
     data_standardised = temporal.standardise_time(data, target_format="%Y-%m-15")
-    assert all(pd.to_datetime(time_value).day == 15 for time_value in data_standardised.time.values)
+    assert all(
+        pd.to_datetime(time_value).day == 15
+        for time_value in data_standardised.forecast_reference_time.values
+    )
 
 
 @pytest.mark.parametrize(
@@ -65,19 +68,19 @@ def test_temporal_reduce_hows(how):
     expected_return_type = xr.Dataset
     reduced_data = temporal.reduce(in_data, how=how)
     assert isinstance(reduced_data, expected_return_type)
-    assert "time" not in list(reduced_data.dims)
+    assert "forecast_reference_time" not in list(reduced_data.dims)
     if expected_return_type == xr.DataArray:
-        assert "t2m" == reduced_data.name
+        assert "2t" == reduced_data.name
     else:
-        assert "t2m" in reduced_data
+        assert "2t" in reduced_data
 
     reduced_data = temporal.reduce(in_data, how=how, how_label=how)
     assert isinstance(reduced_data, expected_return_type)
-    assert "time" not in list(reduced_data.dims)
+    assert "forecast_reference_time" not in list(reduced_data.dims)
     if expected_return_type == xr.DataArray:
-        assert f"t2m_{how}" == reduced_data.name
+        assert f"2t_{how}" == reduced_data.name
     else:
-        assert f"t2m_{how}" in reduced_data
+        assert f"2t_{how}" in reduced_data
 
 
 @pytest.mark.parametrize(
@@ -89,17 +92,17 @@ def test_temporal_reduce_hows(how):
     (
         [get_data(), xr.Dataset],
         [get_data().to_xarray(), xr.Dataset],
-        [get_data().to_xarray().t2m, xr.DataArray],
+        [get_data().to_xarray()["2t"], xr.DataArray],
     ),
 )
 def test_temporal_methods(method, in_data, expected_return_type):
     reduced_data = temporal.__getattribute__(method)(in_data)
     assert isinstance(reduced_data, expected_return_type)
-    assert "time" not in list(reduced_data.dims)
+    assert "forecast_reference_time" not in list(reduced_data.dims)
     if expected_return_type == xr.DataArray:
-        assert "t2m" == reduced_data.name
+        assert "2t" == reduced_data.name
     else:
-        assert "t2m" in reduced_data
+        assert "2t" in reduced_data
 
 
 @pytest.mark.parametrize(
@@ -107,17 +110,17 @@ def test_temporal_methods(method, in_data, expected_return_type):
     (
         [get_data(), xr.Dataset],
         [get_data().to_xarray(), xr.Dataset],
-        [get_data().to_xarray().t2m, xr.DataArray],
+        # [get_data().to_xarray()["2t"], xr.DataArray],
     ),
 )
 def test_temporal_daily_reduce_intypes(in_data, expected_return_type, how="mean"):
     reduced_data = temporal.daily_reduce(in_data, how=how)
     assert isinstance(reduced_data, expected_return_type)
-    assert "time" in list(reduced_data.dims)
+    assert "forecast_reference_time" in list(reduced_data.dims)
     if expected_return_type == xr.DataArray:
-        assert "t2m" == reduced_data.name
+        assert "2t" == reduced_data.name
     else:
-        assert "t2m" in reduced_data
+        assert "2t" in reduced_data
 
 
 @pytest.mark.parametrize(
@@ -127,11 +130,11 @@ def test_temporal_daily_reduce_intypes(in_data, expected_return_type, how="mean"
 def test_temporal_daily_reduce_hows(how, in_data=get_data().to_xarray(), expected_return_type=xr.Dataset):
     reduced_data = temporal.daily_reduce(in_data, how=how)
     assert isinstance(reduced_data, expected_return_type)
-    assert "time" in list(reduced_data.dims)
+    assert "forecast_reference_time" in list(reduced_data.dims)
     if expected_return_type == xr.DataArray:
-        assert "t2m" == reduced_data.name
+        assert "2t" == reduced_data.name
     else:
-        assert "t2m" in reduced_data
+        assert "2t" in reduced_data
 
 
 @pytest.mark.parametrize(
@@ -139,17 +142,17 @@ def test_temporal_daily_reduce_hows(how, in_data=get_data().to_xarray(), expecte
     (
         [get_data(), xr.Dataset],
         [get_data().to_xarray(), xr.Dataset],
-        [get_data().to_xarray().t2m, xr.DataArray],
+        # [get_data().to_xarray()["2t"], xr.DataArray],
     ),
 )
 def test_temporal_monthly_reduce_intypes(in_data, expected_return_type, how="mean"):
     reduced_data = temporal.monthly_reduce(in_data, how=how)
     assert isinstance(reduced_data, expected_return_type)
-    assert "time" in list(reduced_data.dims)
+    assert "forecast_reference_time" in list(reduced_data.dims)
     if expected_return_type == xr.DataArray:
-        assert "t2m" == reduced_data.name
+        assert "2t" == reduced_data.name
     else:
-        assert "t2m" in reduced_data
+        assert "2t" in reduced_data
 
 
 @pytest.mark.parametrize(
@@ -159,11 +162,11 @@ def test_temporal_monthly_reduce_intypes(in_data, expected_return_type, how="mea
 def test_temporal_monthly_reduce_hows(how, in_data=get_data().to_xarray(), expected_return_type=xr.Dataset):
     reduced_data = temporal.monthly_reduce(in_data, how=how)
     assert isinstance(reduced_data, expected_return_type)
-    assert "time" in list(reduced_data.dims)
+    assert "forecast_reference_time" in list(reduced_data.dims)
     if expected_return_type == xr.DataArray:
-        assert "t2m" == reduced_data.name
+        assert "2t" == reduced_data.name
     else:
-        assert "t2m" in reduced_data
+        assert "2t" in reduced_data
 
 
 @pytest.mark.parametrize(
@@ -188,14 +191,14 @@ def test_temporal_monthly_reduce_hows(how, in_data=get_data().to_xarray(), expec
     (
         [get_data(), xr.Dataset],
         [get_data().to_xarray(), xr.Dataset],
-        [get_data().to_xarray().t2m, xr.DataArray],
+        # [get_data().to_xarray()["2t"], xr.DataArray],
     ),
 )
 def test_temporal_daily_monthly_methods(method, in_data, expected_return_type):
     reduced_data = temporal.__getattribute__(method)(in_data)
     assert isinstance(reduced_data, expected_return_type)
-    assert "time" in list(reduced_data.dims)
+    assert "forecast_reference_time" in list(reduced_data.dims)
     if expected_return_type == xr.DataArray:
-        assert "t2m" == reduced_data.name
+        assert "2t" == reduced_data.name
     else:
-        assert "t2m" in reduced_data
+        assert "2t" in reduced_data

--- a/tests/test_40_climatology.py
+++ b/tests/test_40_climatology.py
@@ -106,7 +106,13 @@ def test_climatology_daily(in_data, expected_return_type, method, how):
 def test_anomaly_monthly(in_data, expected_return_type, clim_method):
     clim_m = clim_method(in_data)
     anom_m = climatology.anomaly(in_data, clim_m, frequency="month")
-    assert isinstance(clim_m, expected_return_type)
+    assert isinstance(anom_m, expected_return_type)
+    if expected_return_type == xr.DataArray:
+        assert "2t" == anom_m.name
+    else:
+        assert "2t" in anom_m
+    anom_m = climatology.anomaly(in_data, clim_m, frequency="month", how_label="anomaly")
+    assert isinstance(anom_m, expected_return_type)
     if expected_return_type == xr.DataArray:
         assert "2t_anomaly" == anom_m.name
     else:
@@ -131,7 +137,13 @@ def test_anomaly_monthly(in_data, expected_return_type, clim_method):
 def test_anomaly_daily(in_data, expected_return_type, clim_method):
     clim_d = clim_method(in_data)
     anom_d = climatology.anomaly(in_data, clim_d, frequency="dayofyear")
-    assert isinstance(clim_d, expected_return_type)
+    assert isinstance(anom_d, expected_return_type)
+    if expected_return_type == xr.DataArray:
+        assert "2t" == anom_d.name
+    else:
+        assert "2t" in anom_d
+    anom_d = climatology.anomaly(in_data, clim_d, frequency="dayofyear", how_label="anomaly")
+    assert isinstance(anom_d, expected_return_type)
     if expected_return_type == xr.DataArray:
         assert "2t_anomaly" == anom_d.name
     else:

--- a/tests/test_40_climatology.py
+++ b/tests/test_40_climatology.py
@@ -108,9 +108,9 @@ def test_anomaly_monthly(in_data, expected_return_type, clim_method):
     anom_m = climatology.anomaly(in_data, clim_m, frequency="month")
     assert isinstance(clim_m, expected_return_type)
     if expected_return_type == xr.DataArray:
-        assert "t2m_anomaly" == anom_m.name
+        assert "2t_anomaly" == anom_m.name
     else:
-        assert "t2m_anomaly" in anom_m
+        assert "2t_anomaly" in anom_m
 
 
 @pytest.mark.parametrize(
@@ -133,6 +133,6 @@ def test_anomaly_daily(in_data, expected_return_type, clim_method):
     anom_d = climatology.anomaly(in_data, clim_d, frequency="dayofyear")
     assert isinstance(clim_d, expected_return_type)
     if expected_return_type == xr.DataArray:
-        assert "t2m_anomaly" == anom_d.name
+        assert "2t_anomaly" == anom_d.name
     else:
-        assert "t2m_anomaly" in anom_d
+        assert "2t_anomaly" in anom_d

--- a/tests/test_40_climatology.py
+++ b/tests/test_40_climatology.py
@@ -32,7 +32,7 @@ def get_data():
     (
         [get_data(), xr.Dataset],
         [get_data().to_xarray(), xr.Dataset],
-        [get_data().to_xarray().t2m, xr.DataArray],
+        [get_data().to_xarray()["2t"], xr.DataArray],
     ),
 )
 def test_climatology_monthly(in_data, expected_return_type, method, how):
@@ -40,17 +40,17 @@ def test_climatology_monthly(in_data, expected_return_type, method, how):
     assert isinstance(clim_m, expected_return_type)
     assert "month" in list(clim_m.dims)
     if expected_return_type == xr.DataArray:
-        assert "t2m" == clim_m.name
+        assert "2t" == clim_m.name
     else:
-        assert "t2m" in clim_m
+        assert "2t" in clim_m
 
     clim_m = method(in_data, how_label=how)
     assert isinstance(clim_m, expected_return_type)
     assert "month" in list(clim_m.dims)
     if expected_return_type == xr.DataArray:
-        assert f"t2m_{how}" == clim_m.name
+        assert f"2t_{how}" == clim_m.name
     else:
-        assert f"t2m_{how}" in clim_m
+        assert f"2t_{how}" in clim_m
 
 
 @pytest.mark.parametrize(
@@ -67,7 +67,7 @@ def test_climatology_monthly(in_data, expected_return_type, method, how):
     (
         [get_data(), xr.Dataset],
         [get_data().to_xarray(), xr.Dataset],
-        [get_data().to_xarray().t2m, xr.DataArray],
+        [get_data().to_xarray()["2t"], xr.DataArray],
     ),
 )
 def test_climatology_daily(in_data, expected_return_type, method, how):
@@ -75,17 +75,17 @@ def test_climatology_daily(in_data, expected_return_type, method, how):
     assert isinstance(clim_d, expected_return_type)
     assert "dayofyear" in list(clim_d.dims)
     if expected_return_type == xr.DataArray:
-        assert "t2m" == clim_d.name
+        assert "2t" == clim_d.name
     else:
-        assert "t2m" in clim_d
+        assert "2t" in clim_d
 
     clim_d = method(in_data, how_label=how)
     assert isinstance(clim_d, expected_return_type)
     assert "dayofyear" in list(clim_d.dims)
     if expected_return_type == xr.DataArray:
-        assert f"t2m_{how}" == clim_d.name
+        assert f"2t_{how}" == clim_d.name
     else:
-        assert f"t2m_{how}" in clim_d
+        assert f"2t_{how}" in clim_d
 
 
 @pytest.mark.parametrize(
@@ -100,7 +100,7 @@ def test_climatology_daily(in_data, expected_return_type, method, how):
     (
         [get_data(), xr.Dataset],
         [get_data().to_xarray(), xr.Dataset],
-        [get_data().to_xarray().t2m, xr.DataArray],
+        [get_data().to_xarray()["2t"], xr.DataArray],
     ),
 )
 def test_anomaly_monthly(in_data, expected_return_type, clim_method):
@@ -125,7 +125,7 @@ def test_anomaly_monthly(in_data, expected_return_type, clim_method):
     (
         [get_data(), xr.Dataset],
         [get_data().to_xarray(), xr.Dataset],
-        [get_data().to_xarray().t2m, xr.DataArray],
+        [get_data().to_xarray()["2t"], xr.DataArray],
     ),
 )
 def test_anomaly_daily(in_data, expected_return_type, clim_method):


### PR DESCRIPTION
Updates required to use the earthkit-data xarray engine as default

- expanded dimension detection to find CF standard_names
- updated standardise_time to use time dim detection
- Tests updated to match default xarray format
- rasterio only installed in `[all]` mode
- spatial tests skipped if rasterio not installed


Additional updates:
- Updated output variable labelling for anomaly method to match other methods, i.e. use `how_label`

