### PR TITLE
simplify spatial.py

### DIFF
--- a/src/earthkit/transforms/aggregate/spatial.py
+++ b/src/earthkit/transforms/aggregate/spatial.py
@@ -143,8 +143,8 @@ def mask_contains_points(
 
     # get spatial dims and create output array:
     spatial_dims = list(set(lat_dims + lon_dims))
-    outdata_shape = [len(coords[dim]) for dim in spatial_dims]
-    outdata = xp.zeros(outdata_shape).astype(bool) * xp.nan
+    outdata_shape = tuple(len(coords[dim]) for dim in spatial_dims)
+    outdata = xp.full(outdata_shape, xp.nan)
     # loop over shapes and mask any point that is in the shape
     for shape in shape_list:
         for shp in shape[0]:


### PR DESCRIPTION
### Description
Very minor but I noticed we can simplify the outdata construction logic.

I did also notice that we do in-place assignment afterward with the following
```python
outdata.flat[path.contains_points(points)] = True
```
Just thought I'd flag it (I have the same issues with this in ekh) because sadly this is not in the array-api specification which is a big pain.
Also, the True gets converted to a 1 because the outdata is of type float - not sure if this is intended?

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 