### PR TITLE
regular check for evenly spaced

### DIFF
--- a/src/earthkit/transforms/_tools.py
+++ b/src/earthkit/transforms/_tools.py
@@ -628,12 +628,36 @@ def get_dim_key(
     return axis
 
 
+def _is_evenly_spaced(coord) -> bool:
+    """Check whether a 1-D coordinate array has uniform spacing.
+
+    Parameters
+    ----------
+    coord : array-like
+        A 1-D array of coordinate values.
+
+    Returns
+    -------
+    bool
+        ``True`` if all consecutive differences are equal (within
+        floating-point tolerance), ``False`` otherwise.
+        Arrays with fewer than 2 elements are trivially uniform.
+
+    """
+    values = np.asarray(coord)
+    if values.size < 2:
+        return True
+    diffs = np.diff(values)
+    return bool(np.allclose(diffs, diffs[0]))
+
+
 def get_spatial_info(dataarray, lat_key=None, lon_key=None):
     """Return a dictionary of spatial metadata for a DataArray.
 
     Detects latitude and longitude coordinate names, their associated
-    dimensions, and whether the grid is regular (1-D lat/lon coordinates)
-    or irregular (shared dimensions, e.g. obs or curvilinear grids).
+    dimensions, and whether the grid is regular (1-D, evenly-spaced
+    lat/lon coordinates) or irregular (shared dimensions, or
+    non-uniform spacing).
 
     Parameters
     ----------
@@ -653,7 +677,8 @@ def get_spatial_info(dataarray, lat_key=None, lon_key=None):
 
         - ``'lat_key'`` (str): name of the latitude coordinate.
         - ``'lon_key'`` (str): name of the longitude coordinate.
-        - ``'regular'`` (bool): ``True`` if the grid is regular, ``False`` if irregular.
+        - ``'regular'`` (bool): ``True`` if the grid is regular (latitude and longitude are 1-D and
+          evenly spaced), ``False`` if irregular.
         - ``'spatial_dims'`` (list[str]): list of spatial dimension names.
 
     """
@@ -675,7 +700,9 @@ def get_spatial_info(dataarray, lat_key=None, lon_key=None):
     if lat_dims == lon_dims:
         regular = False
     elif (lat_dims == (lat_key,)) and (lon_dims) == (lon_key,):
-        regular = True
+        regular = _is_evenly_spaced(dataarray.coords[lat_key].values) and _is_evenly_spaced(
+            dataarray.coords[lon_key].values
+        )
     else:
         raise ValueError(
             "The geospatial dimensions have not not been correctly detected:\n"

--- a/tests/legacy-api/test_legacy_10_tools.py
+++ b/tests/legacy-api/test_legacy_10_tools.py
@@ -11,6 +11,7 @@ import pytest
 import xarray as xr
 
 from earthkit.transforms._tools import (
+    _is_evenly_spaced,
     get_dim_key,
     get_how,
     get_how_xp,
@@ -300,6 +301,36 @@ def test_get_spatial_info():
     # Check if the correct dimension key is returned
     expected_result = {"lat_key": "lat", "lon_key": "lon", "regular": True, "spatial_dims": ["lat", "lon"]}
     assert expected_result == get_spatial_info(dataarray)
+
+
+def test_get_spatial_info_non_uniform():
+    """1-D lat/lon that are not evenly spaced should return regular=False."""
+    dataarray = xr.DataArray(
+        np.ones((3, 4)),
+        dims=("lat", "lon"),
+        coords={
+            "lat": [0.0, 1.0, 3.0],  # non-uniform spacing
+            "lon": [0.0, 1.0, 2.0, 3.0],  # uniform
+        },
+    )
+    result = get_spatial_info(dataarray)
+    assert result["regular"] is False
+    assert result["spatial_dims"] == ["lat", "lon"]
+
+
+@pytest.mark.parametrize(
+    "values, expected",
+    [
+        ([1.0, 2.0, 3.0, 4.0], True),  # uniform
+        ([0.0, 1.0, 3.0], False),  # non-uniform
+        ([5.0], True),  # single element
+        ([], True),  # empty
+        ([1.0, 2.0 + 1e-12, 3.0], True),  # FP noise within tolerance
+        ([-90.0, -60.0, -30.0, 0.0, 30.0, 60.0, 90.0], True),  # typical lat grid
+    ],
+)
+def test_is_evenly_spaced(values, expected):
+    assert _is_evenly_spaced(np.array(values)) is expected
 
 
 def test_latitude_weights():

--- a/tests/test_10_tools.py
+++ b/tests/test_10_tools.py
@@ -11,6 +11,7 @@ import pytest
 import xarray as xr
 
 from earthkit.transforms._tools import (
+    _is_evenly_spaced,
     ensure_list,
     get_dim_key,
     get_how,
@@ -307,6 +308,36 @@ def test_get_spatial_info():
     # Check if the correct dimension key is returned
     expected_result = {"lat_key": "lat", "lon_key": "lon", "regular": True, "spatial_dims": ["lat", "lon"]}
     assert expected_result == get_spatial_info(dataarray)
+
+
+def test_get_spatial_info_non_uniform():
+    """1-D lat/lon that are not evenly spaced should return regular=False."""
+    dataarray = xr.DataArray(
+        np.ones((3, 4)),
+        dims=("lat", "lon"),
+        coords={
+            "lat": [0.0, 1.0, 3.0],  # non-uniform spacing
+            "lon": [0.0, 1.0, 2.0, 3.0],  # uniform
+        },
+    )
+    result = get_spatial_info(dataarray)
+    assert result["regular"] is False
+    assert result["spatial_dims"] == ["lat", "lon"]
+
+
+@pytest.mark.parametrize(
+    "values, expected",
+    [
+        ([1.0, 2.0, 3.0, 4.0], True),  # uniform
+        ([0.0, 1.0, 3.0], False),  # non-uniform
+        ([5.0], True),  # single element
+        ([], True),  # empty
+        ([1.0, 2.0 + 1e-12, 3.0], True),  # FP noise within tolerance
+        ([-90.0, -60.0, -30.0, 0.0, 30.0, 60.0, 90.0], True),  # typical lat grid
+    ],
+)
+def test_is_evenly_spaced(values, expected):
+    assert _is_evenly_spaced(np.array(values)) is expected
 
 
 def test_latitude_weights():


### PR DESCRIPTION
### Description

Add an additional check to the "regular" check for get_spatial_info to check if the lat and lon dimensions are evenly spaced. This is required for the rasterize function to work correctly.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
