### PR TITLE
1D Convolution

### DIFF
--- a/docs/source/how-tos/temporal/howto_apply_smoothing_kernel_era5.ipynb
+++ b/docs/source/how-tos/temporal/howto_apply_smoothing_kernel_era5.ipynb
@@ -1,0 +1,65 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Apply a Smoothing Kernel\n",
+    "\n",
+    "This notebook demonstrates how to apply a smoothing kernel to some sample 2m temperature from ERA5 data using earthkit-data and earthkit-transforms.\n",
+    "Smoothing kernels are useful for filtering high-frequency noise while preserving longer-term variability in a time series."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-29T12:06:19.831660Z",
+     "iopub.status.busy": "2026-07-29T12:06:19.831420Z",
+     "iopub.status.idle": "2026-07-29T12:06:24.789456Z",
+     "shell.execute_reply": "2026-07-29T12:06:24.788951Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from earthkit import data as ekd\n",
+    "from earthkit import transforms as ekt\n",
+    "from earthkit.transforms._tools import earthkit_remote_test_data_file\n",
+    "\n",
+    "remote_era5_file = earthkit_remote_test_data_file(\"era5-Europe-sfc-2m-temperature-3deg-2015-2017.grib\")\n",
+    "era5_data = ekd.from_source(\"url\", remote_era5_file)\n",
+    "ds = era5_data.to_xarray()\n",
+    "\n",
+    "# ~7-day normalised Hann window (29 six-hourly steps)\n",
+    "window = np.hanning(29)\n",
+    "window = window / window.sum()\n",
+    "\n",
+    "smoothed = ekt.temporal.convolve(ds, window, remove_partial_periods=True)\n",
+    "smoothed"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "earthkit-transforms (3.14.4)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/source/how-tos/temporal/howto_apply_smoothing_kernel_era5.ipynb
+++ b/docs/source/how-tos/temporal/howto_apply_smoothing_kernel_era5.ipynb
@@ -13,14 +13,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-29T12:06:19.831660Z",
-     "iopub.status.busy": "2026-07-29T12:06:19.831420Z",
-     "iopub.status.idle": "2026-07-29T12:06:24.789456Z",
-     "shell.execute_reply": "2026-07-29T12:06:24.788951Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",

--- a/docs/source/how-tos/temporal/index.rst
+++ b/docs/source/how-tos/temporal/index.rst
@@ -13,3 +13,4 @@ and standard deviation.
    howto_calculate_daily_mean_era5.ipynb
    howto_calculate_monthly_mean_era5.ipynb
    howto_compute_in_local_time.ipynb
+   howto_apply_smoothing_kernel_era5.ipynb

--- a/src/earthkit/transforms/__init__.py
+++ b/src/earthkit/transforms/__init__.py
@@ -29,6 +29,7 @@ from earthkit.transforms import (
 )
 
 from ._aggregate import reduce, resample, rolling_reduce
+from ._convolve import convolve
 
 # For backwards compatibility
 tools = _tools
@@ -45,4 +46,5 @@ __all__ = [
     "reduce",
     "rolling_reduce",
     "resample",
+    "convolve",
 ]

--- a/src/earthkit/transforms/_convolve.py
+++ b/src/earthkit/transforms/_convolve.py
@@ -12,15 +12,18 @@
 # limitations under the License.
 
 import warnings
-from typing import Literal
+from typing import Literal, TypeVar
 
 import xarray as xr
+from earthkit.utils.array import array_namespace
+from numpy.typing import ArrayLike
 
 from earthkit.transforms._aggregate import how_label_rename
-from earthkit.utils.array import array_namespace
+
+T = TypeVar("T", xr.DataArray, xr.Dataset)
 
 
-def convolve(dataarray: xr.DataArray | xr.Dataset, *_args, **kwargs):
+def convolve(dataarray: T, *_args, **kwargs) -> T:
     r"""Convolve an xarray.dataarray or xarray.dataset with a 1-D window along a dimension.
 
     Parameters
@@ -40,19 +43,18 @@ def convolve(dataarray: xr.DataArray | xr.Dataset, *_args, **kwargs):
         How the convolution is evaluated:
 
         - ``"auto"``: automatically select a method based on the inputs.
-        - ``"direct"``: implementation as a windowed dot product. Preserves the
-          input dtype and propagates ``NaN`` locally.
+        - ``"direct"``: implementation as a windowed dot product. Propagates
+          ``NaN`` values locally.
         - ``"fft"``: evaluated in the frequency domain via the convolution
           theorem. Fastest for longer windows. Casts all inputs to float and
           spreads ``NaN`` values across the entire convolution axis.
-    how_label : str | None
+    how_label : str | None, default: None
         Label to append to the name of the variable in the convoluted object,
         default is nothing.
 
     Returns
     -------
-    xarray.DataArray
-        The result of the convolution.
+    xarray.DataArray or xarray.Dataset (as provided)
 
     Notes
     -----
@@ -79,13 +81,13 @@ def convolve(dataarray: xr.DataArray | xr.Dataset, *_args, **kwargs):
 
 def _convolve_dataarray(
     dataarray: xr.DataArray,
-    window: "array_like",
+    window: ArrayLike,
     dim: str,
     *,
     how_boundary: Literal["zeropad"] | Literal["periodic"] = "zeropad",
     how_method: Literal["auto"] | Literal["direct"] | Literal["fft"] = "auto",
-    how_label: str = None,
-):
+    how_label: str | None = None,
+) -> xr.DataArray:
     r"""Convolve a data array with a 1-D window along a single dimension.
 
     Parameters
@@ -100,14 +102,14 @@ def _convolve_dataarray(
         How the signal is extended where the window overhangs.
     how_method : {"auto", "direct", "fft"}, default: "auto"
         How the convolution is evaluated.
-    how_label : str | None
+    how_label : str | None, default: None
         Label to append to the name of the variable in the convoluted object,
         default is nothing.
 
     Returns
     -------
     xarray.DataArray
-        The result of the convolution.
+        Result of the convolution.
     """
     if dim not in dataarray.dims:
         raise ValueError(f"dim={dim!r} not found in dataarray dimensions {dataarray.dims}")

--- a/src/earthkit/transforms/_convolve.py
+++ b/src/earthkit/transforms/_convolve.py
@@ -112,16 +112,25 @@ def _convolve_dataarray(
     xarray.DataArray
         The result of the convolution.
     """
-    xp = array_namespace(dataarray.data)
+    if dim not in dataarray.dims:
+        raise ValueError(f"dim={dim!r} not found in dataarray dimensions {dataarray.dims}")
 
+    xp = array_namespace(dataarray.data)
     window = xp.asarray(window)
-    assert window.ndim == 1
+    if window.ndim != 1:
+        raise ValueError(f"window must be 1-dimensional, got window.ndim={window.ndim}")
+    if window.size == 0:
+        raise ValueError("window must be non-empty")
 
     method = (how_method, how_boundary)
     if method not in _CONVOLVE_METHODS:
-        raise NotImplementedError(method)
-    convolved = _CONVOLVE_METHODS[method](dataarray, window, dim)
+        available = ", ".join(f"{m!r} and {b!r}" for m, b in _CONVOLVE_METHODS)
+        raise ValueError(
+            f"Unsupported combination how_method and how_boundary: {how_method!r} and {how_boundary!r}. "
+            f"Available combinations are: {available}"
+        )
 
+    convolved = _CONVOLVE_METHODS[method](dataarray, window, dim)
     convolved = how_label_rename(convolved, how_label=how_label)
     return convolved
 
@@ -141,7 +150,7 @@ def _convolve_dataarray_direct_zeropad(dataarray, window, dim):
 
 def _convolve_array_fft(signal, window, axis, n):
     if signal.dtype.kind != "f" or window.dtype.kind != "f":
-        warnings.warn("fft-based convolution casts inputs to float")
+        warnings.warn("FFT-based convolution casts inputs to float")
     xp = array_namespace(signal)
     window = xp.asarray(window)
     window_axis_pad = (xp.newaxis,) * (signal.ndim - axis - 1)

--- a/src/earthkit/transforms/_convolve.py
+++ b/src/earthkit/transforms/_convolve.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 import warnings
+from typing import Literal
 
 import xarray as xr
 
@@ -19,7 +20,56 @@ from earthkit.transforms._aggregate import how_label_rename
 from earthkit.utils.array import array_namespace
 
 
-def convolve(dataarray, *_args, **kwargs):
+def convolve(
+    dataarray: xr.DataArray | xr.Dataset,
+    *_args,
+    **kwargs
+):
+    r"""Convolve an xarray.dataarray or xarray.dataset with a 1-D window along a dimension.
+
+    Parameters
+    ----------
+    dataarray : xarray.DataArray | xarray.Dataset
+        First input to the convolution.
+    window : array_like
+        Second input to the convolution, a 1-D kernel.
+    dim : str
+        Dimension along which to convolve the inputs.
+    how_boundary : {"zeropad", "periodic"}, default: "zeropad"
+        How the signal is extended where the window overhangs an edge:
+
+        - ``"zeropad"``: the signal is extended with zeros.
+        - ``"periodic"``: the signal wraps around.
+    how_method : {"direct", "fft"}, default: "direct"
+        How the convolution is evaluated:
+
+        - ``"direct"``: implementation as a windowed dot product. Preserves the
+          input dtype and propagates ``NaN`` locally.
+        - ``"fft"``: evaluated in the frequency domain via the convolution
+          theorem. Faster for long windows, but casts all inputs to float and
+          spreads ``NaN`` values across the entire convolution axis.
+    how_label : str | None
+        Label to append to the name of the variable in the convoluted object,
+        default is nothing.
+
+    Returns
+    -------
+    xarray.DataArray
+        The result of the convolution.
+
+    Notes
+    -----
+    For a signal :math:`f` of length :math:`n` and a window :math:`g` of length
+    :math:`k`, the output along ``dim`` is the centered discrete convolution
+
+    .. math::
+
+        (f * g)_i = \sum_{j=0}^{k-1} g_j \, f_{i + s - j},
+        \qquad s = \left\lfloor \frac{k - 1}{2} \right\rfloor,
+
+    for :math:`i = 0, \dots, n - 1`. Note that signal and window indices run in
+    opposite directions to obtain true convolution instead of cross-correlation.
+    """
     if isinstance(dataarray, xr.Dataset):
         out_ds = xr.Dataset().assign_attrs(dataarray.attrs)
         for var in dataarray.data_vars:
@@ -31,37 +81,38 @@ def convolve(dataarray, *_args, **kwargs):
 
 
 def _convolve_dataarray(
-    dataarray,
-    window,
-    dim,
+    dataarray: xr.DataArray,
+    window: "array_like",
+    dim: str,
     *,
-    how_boundary="zeropad",
-    how_method="direct",
-    how_label=None
+    how_boundary: Literal["zeropad"] | Literal["periodic"] = "zeropad",
+    how_method: Literal["direct"] | Literal["fft"] = "direct",
+    how_label: str = None
 ):
-    """Convolution.
+    r"""Convolve a data array with a 1-D window along a single dimension.
 
     Parameters
     ----------
     dataarray : xarray.DataArray
         First input to the convolution.
     window : array_like
-        Second input to the convolution.
+        Second input to the convolution, a 1-D kernel.
     dim : str
         Dimension along which to convolve the inputs.
-    how_boundary : "zeropad" | "periodic"
-        Boundary handling.
-    how_method : "direct" | "fft"
-        Implementation of convolution. FFT-based convolution only works for
-        float-type inputs without NaNs.
+    how_boundary : {"zeropad", "periodic"}, default: "zeropad"
+        How the signal is extended where the window overhangs an edge.
+    how_method : {"direct", "fft"}, default: "direct"
+        How the convolution is evaluated.
     how_label : str | None
-        Label to append to the name of the variable in the convoluted object, default is nothing
+        Label to append to the name of the variable in the convoluted object,
+        default is nothing.
 
     Returns
     -------
     xarray.DataArray
+        The result of the convolution.
     """
-    xp = array_namespace(dataarray.data, window)
+    xp = array_namespace(dataarray.data)
 
     window = xp.asarray(window)
     assert window.ndim == 1
@@ -76,7 +127,8 @@ def _convolve_dataarray(
 
 
 def _convolve_dataarray_direct_zeropad(dataarray, window, dim):
-    window = window[::-1].copy()  # Reverse kernel to get convolution from dot-product
+    # Reverse kernel to get true convolution from dot-product
+    window = window[::-1].copy()
     k = window.size
     window_dim = f"__convolve_dim_{dim}"
     window_da = xr.DataArray(window, dims=[window_dim])
@@ -90,10 +142,11 @@ def _convolve_dataarray_direct_zeropad(dataarray, window, dim):
 def _convolve_array_fft(signal, window, axis, n):
     if signal.dtype.kind != "f" or window.dtype.kind != "f":
         warnings.warn("fft-based convolution casts inputs to float")
-    xp = array_namespace(signal, window)
+    xp = array_namespace(signal)
+    window = xp.asarray(window)
     window_axis_pad = (xp.newaxis,) * (signal.ndim - axis - 1)
     fft_sig = xp.fft.rfft(signal, axis=axis, n=n)
-    fft_win = xp.fft.rfft(window, n=n)[:, *window_axis_pad]  # TODO py311 only
+    fft_win = xp.fft.rfft(window, n=n)[(slice(None), *window_axis_pad)]
     return xp.fft.irfft(fft_sig * fft_win, axis=axis, n=n)
 
 

--- a/src/earthkit/transforms/_convolve.py
+++ b/src/earthkit/transforms/_convolve.py
@@ -32,7 +32,7 @@ def convolve(dataarray: xr.DataArray | xr.Dataset, *_args, **kwargs):
     dim : str
         Dimension along which to convolve the inputs.
     how_boundary : {"zeropad", "periodic"}, default: "zeropad"
-        How the signal is extended where the window overhangs an edge:
+        How the signal is extended where the window overhangs:
 
         - ``"zeropad"``: the signal is extended with zeros.
         - ``"periodic"``: the signal wraps around.
@@ -97,7 +97,7 @@ def _convolve_dataarray(
     dim : str
         Dimension along which to convolve the inputs.
     how_boundary : {"zeropad", "periodic"}, default: "zeropad"
-        How the signal is extended where the window overhangs an edge.
+        How the signal is extended where the window overhangs.
     how_method : {"auto", "direct", "fft"}, default: "auto"
         How the convolution is evaluated.
     how_label : str | None

--- a/src/earthkit/transforms/_convolve.py
+++ b/src/earthkit/transforms/_convolve.py
@@ -1,0 +1,127 @@
+# Copyright 2026-, European Centre for Medium Range Weather Forecasts.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+
+import xarray as xr
+
+from earthkit.transforms._aggregate import how_label_rename
+from earthkit.utils.array import array_namespace
+
+
+def convolve(dataarray, *_args, **kwargs):
+    if isinstance(dataarray, xr.Dataset):
+        out_ds = xr.Dataset().assign_attrs(dataarray.attrs)
+        for var in dataarray.data_vars:
+            out_da = _convolve_dataarray(dataarray[var], *_args, **kwargs)
+            out_ds[out_da.name] = out_da
+        return out_ds
+    else:
+        return _convolve_dataarray(dataarray, *_args, **kwargs)
+
+
+def _convolve_dataarray(
+    dataarray,
+    window,
+    dim,
+    *,
+    how_boundary="zeropad",
+    how_method="direct",
+    how_label=None
+):
+    """Convolution.
+
+    Parameters
+    ----------
+    dataarray : xarray.DataArray
+        First input to the convolution.
+    window : array_like
+        Second input to the convolution.
+    dim : str
+        Dimension along which to convolve the inputs.
+    how_boundary : "zeropad" | "periodic"
+        Boundary handling.
+    how_method : "direct" | "fft"
+        Implementation of convolution. FFT-based convolution only works for
+        float-type inputs without NaNs.
+    how_label : str | None
+        Label to append to the name of the variable in the convoluted object, default is nothing
+
+    Returns
+    -------
+    xarray.DataArray
+    """
+    xp = array_namespace(dataarray.data, window)
+
+    window = xp.asarray(window)
+    assert window.ndim == 1
+
+    method = (how_method, how_boundary)
+    if method not in _CONVOLVE_METHODS:
+        raise NotImplementedError(method)
+    convolved = _CONVOLVE_METHODS[method](dataarray, window, dim)
+
+    convolved = how_label_rename(convolved, how_label=how_label)
+    return convolved
+
+
+def _convolve_dataarray_direct_zeropad(dataarray, window, dim):
+    window = window[::-1].copy()  # Reverse kernel to get convolution from dot-product
+    k = window.size
+    window_dim = f"__convolve_dim_{dim}"
+    window_da = xr.DataArray(window, dims=[window_dim])
+    zero = dataarray.dtype.type(0)
+    rolled = dataarray.rolling({dim: k}, center=True).construct(window_dim, fill_value=zero)
+    result = (rolled * window_da).sum(dim=window_dim, skipna=False)
+    # Multiplying by the (unnamed) window_da drops .name; restore it
+    return result.rename(dataarray.name)
+
+
+def _convolve_array_fft(signal, window, axis, n):
+    if signal.dtype.kind != "f" or window.dtype.kind != "f":
+        warnings.warn("fft-based convolution casts inputs to float")
+    xp = array_namespace(signal, window)
+    window_axis_pad = (xp.newaxis,) * (signal.ndim - axis - 1)
+    fft_sig = xp.fft.rfft(signal, axis=axis, n=n)
+    fft_win = xp.fft.rfft(window, n=n)[:, *window_axis_pad]  # TODO py311 only
+    return xp.fft.irfft(fft_sig * fft_win, axis=axis, n=n)
+
+
+def _convolve_dataarray_fft_zeropad(dataarray, window, dim):
+    nsig = dataarray.sizes[dim]
+    nwin = window.size
+    nfft = nsig + nwin - 1
+    axis = dataarray.get_axis_num(dim)
+    convolved = _convolve_array_fft(dataarray.data, window, axis=axis, n=nfft)
+    # Consistent with direct implementation and centering convention of xarray
+    start = (nwin - 1) // 2
+    slicer = [slice(None)] * dataarray.ndim
+    slicer[axis] = slice(start, start + nsig)
+    return dataarray.copy(data=convolved[tuple(slicer)])
+
+
+def _convolve_dataarray_fft_periodic(dataarray, window, dim):
+    xp = array_namespace(dataarray.data, window)
+    nsig = dataarray.sizes[dim]
+    start = (window.size - 1) // 2
+    axis = dataarray.get_axis_num(dim)
+    convolved = _convolve_array_fft(dataarray.data, window, axis=axis, n=nsig)
+    convolved = xp.roll(convolved, -start, axis=axis)
+    return dataarray.copy(data=convolved)
+
+
+_CONVOLVE_METHODS = {
+    ("direct", "zeropad"): _convolve_dataarray_direct_zeropad,
+    ("fft", "zeropad"): _convolve_dataarray_fft_zeropad,
+    ("fft", "periodic"): _convolve_dataarray_fft_periodic,
+}

--- a/src/earthkit/transforms/_convolve.py
+++ b/src/earthkit/transforms/_convolve.py
@@ -120,8 +120,10 @@ def _convolve_dataarray(
         raise ValueError("window must be non-empty")
 
     if how_method == "auto":
-        # FFT is float-only, so choose direct method when result has any other type
-        how_method_proposed = "fft" if dataarray.dtype.kind == "f" or window.dtype.kind == "f" else "direct"
+        # FFT is float-only and cannot operate along a dim split into multiple chunks
+        is_float = dataarray.dtype.kind == "f" or window.dtype.kind == "f"
+        is_multi_chunked = len(dataarray.chunksizes.get(dim, ())) > 1
+        how_method_proposed = "fft" if is_float and not is_multi_chunked else "direct"
         if (how_method_proposed, how_boundary) not in _CONVOLVE_METHODS:
             raise RuntimeError(
                 f"Unable to auto-select a method for input and boundary {how_boundary!r}. "

--- a/src/earthkit/transforms/_convolve.py
+++ b/src/earthkit/transforms/_convolve.py
@@ -40,9 +40,10 @@ def convolve(
 
         - ``"zeropad"``: the signal is extended with zeros.
         - ``"periodic"``: the signal wraps around.
-    how_method : {"direct", "fft"}, default: "direct"
+    how_method : {"auto", "direct", "fft"}, default: "auto"
         How the convolution is evaluated:
 
+        - ``"auto"``: automatically select a method based on the inputs.
         - ``"direct"``: implementation as a windowed dot product. Preserves the
           input dtype and propagates ``NaN`` locally.
         - ``"fft"``: evaluated in the frequency domain via the convolution
@@ -86,7 +87,7 @@ def _convolve_dataarray(
     dim: str,
     *,
     how_boundary: Literal["zeropad"] | Literal["periodic"] = "zeropad",
-    how_method: Literal["direct"] | Literal["fft"] = "direct",
+    how_method: Literal["auto"] | Literal["direct"] | Literal["fft"] = "auto",
     how_label: str = None
 ):
     r"""Convolve a data array with a 1-D window along a single dimension.
@@ -101,7 +102,7 @@ def _convolve_dataarray(
         Dimension along which to convolve the inputs.
     how_boundary : {"zeropad", "periodic"}, default: "zeropad"
         How the signal is extended where the window overhangs an edge.
-    how_method : {"direct", "fft"}, default: "direct"
+    how_method : {"auto", "direct", "fft"}, default: "auto"
         How the convolution is evaluated.
     how_label : str | None
         Label to append to the name of the variable in the convoluted object,
@@ -122,11 +123,21 @@ def _convolve_dataarray(
     if window.size == 0:
         raise ValueError("window must be non-empty")
 
+    if how_method == "auto":
+        # FFT is float-only, so choose direct method when result has any other type
+        how_method_proposed = "fft" if dataarray.dtype.kind == "f" or window.dtype.kind == "f" else "direct"
+        if (how_method_proposed, how_boundary) not in _CONVOLVE_METHODS:
+            raise ValueError(
+                f"Unable to auto-select a method for input and boundary {how_boundary!r}. "
+                "Please select a method and boundary combination explicitly."
+            )
+        how_method = how_method_proposed
+
     method = (how_method, how_boundary)
     if method not in _CONVOLVE_METHODS:
         available = ", ".join(f"{m!r} and {b!r}" for m, b in _CONVOLVE_METHODS)
         raise ValueError(
-            f"Unsupported combination how_method and how_boundary: {how_method!r} and {how_boundary!r}. "
+            f"Unsupported combination of method and boundary: {how_method!r} and {how_boundary!r}. "
             f"Available combinations are: {available}"
         )
 
@@ -151,8 +162,7 @@ def _convolve_dataarray_direct_zeropad(dataarray, window, dim):
 def _convolve_array_fft(signal, window, axis, n):
     if signal.dtype.kind != "f" or window.dtype.kind != "f":
         warnings.warn("FFT-based convolution casts inputs to float")
-    xp = array_namespace(signal)
-    window = xp.asarray(window)
+    xp = array_namespace(signal, window)
     window_axis_pad = (xp.newaxis,) * (signal.ndim - axis - 1)
     fft_sig = xp.fft.rfft(signal, axis=axis, n=n)
     fft_win = xp.fft.rfft(window, n=n)[(slice(None), *window_axis_pad)]

--- a/src/earthkit/transforms/_convolve.py
+++ b/src/earthkit/transforms/_convolve.py
@@ -12,15 +12,17 @@
 # limitations under the License.
 
 import warnings
-from typing import Literal, TypeVar
+from typing import Callable, Literal, Mapping, TypeVar
 
+import numpy as np
 import xarray as xr
 from earthkit.utils.array import array_namespace
-from numpy.typing import ArrayLike
 
 from earthkit.transforms._aggregate import how_label_rename
 
 T = TypeVar("T", xr.DataArray, xr.Dataset)
+BoundaryT = Literal["zeropad", "periodic"]
+MethodT = Literal["auto", "direct", "fft"]
 
 
 def convolve(dataarray: T, *_args, **kwargs) -> T:
@@ -81,11 +83,11 @@ def convolve(dataarray: T, *_args, **kwargs) -> T:
 
 def _convolve_dataarray(
     dataarray: xr.DataArray,
-    window: ArrayLike,
+    window: np.typing.ArrayLike,
     dim: str,
     *,
-    how_boundary: Literal["zeropad"] | Literal["periodic"] = "zeropad",
-    how_method: Literal["auto"] | Literal["direct"] | Literal["fft"] = "auto",
+    how_boundary: BoundaryT = "zeropad",
+    how_method: MethodT = "auto",
     how_label: str | None = None,
 ) -> xr.DataArray:
     r"""Convolve a data array with a 1-D window along a single dimension.
@@ -115,17 +117,17 @@ def _convolve_dataarray(
         raise ValueError(f"dim={dim!r} not found in dataarray dimensions {dataarray.dims}")
 
     xp = array_namespace(dataarray.data)
-    window = xp.asarray(window)
-    if window.ndim != 1:
-        raise ValueError(f"window must be 1-dimensional, got window.ndim={window.ndim}")
-    if window.size == 0:
+    kernel = xp.asarray(window)
+    if kernel.ndim != 1:
+        raise ValueError(f"window must be 1-dimensional, got window.ndim={kernel.ndim}")
+    if kernel.size == 0:
         raise ValueError("window must be non-empty")
 
     if how_method == "auto":
         # FFT is float-only and cannot operate along a dim split into multiple chunks
-        is_float = dataarray.dtype.kind == "f" or window.dtype.kind == "f"
+        is_float = dataarray.dtype.kind == "f" or kernel.dtype.kind == "f"
         is_multi_chunked = len(dataarray.chunksizes.get(dim, ())) > 1
-        how_method_proposed = "fft" if is_float and not is_multi_chunked else "direct"
+        how_method_proposed: MethodT = "fft" if is_float and not is_multi_chunked else "direct"
         if (how_method_proposed, how_boundary) not in _CONVOLVE_METHODS:
             raise RuntimeError(
                 f"Unable to auto-select a method for input and boundary {how_boundary!r}. "
@@ -141,61 +143,61 @@ def _convolve_dataarray(
             f"Available combinations are: {available}"
         )
 
-    convolved = _CONVOLVE_METHODS[method](dataarray, window, dim)
+    convolved = _CONVOLVE_METHODS[method](dataarray, kernel, dim)
     convolved = how_label_rename(convolved, how_label=how_label)
     return convolved
 
 
-def _convolve_dataarray_direct_zeropad(dataarray, window, dim):
+def _convolve_dataarray_direct_zeropad(dataarray, kernel, dim):
     """Rolling dot product-based convolution with zero-padding at the boundary."""
-    window = window[::-1].copy()  # reverse kernel for true convolution
-    k = window.size
-    window_dim = f"__convolve_dim_{dim}"
-    window_da = xr.DataArray(window, dims=[window_dim])
+    kernel = kernel[::-1].copy()  # reverse kernel for true convolution
+    k = kernel.size
+    kernel_dim = f"__convolve_dim_{dim}"
+    kernel_da = xr.DataArray(kernel, dims=[kernel_dim])
     return (
         dataarray.rolling({dim: k}, center=True)
-        .construct(window_dim, fill_value=dataarray.dtype.type(0))
-        .dot(window_da, dim=window_dim)
+        .construct(kernel_dim, fill_value=dataarray.dtype.type(0))
+        .dot(kernel_da, dim=kernel_dim)
     )
 
 
-def _convolve_array_fft(signal, window, axis, n, xp):
+def _convolve_array_fft(signal, kernel, axis, n, xp):
     """Generic FFT-based convolution."""
-    if signal.dtype.kind != "f" or window.dtype.kind != "f":
+    if signal.dtype.kind != "f" or kernel.dtype.kind != "f":
         warnings.warn("FFT-based convolution casts inputs to float")
-    window_axis_pad = (xp.newaxis,) * (signal.ndim - axis - 1)
+    kernel_axis_pad = (xp.newaxis,) * (signal.ndim - axis - 1)
     fft_sig = xp.fft.rfft(signal, axis=axis, n=n)
-    fft_win = xp.fft.rfft(window, n=n)[(slice(None), *window_axis_pad)]
-    return xp.fft.irfft(fft_sig * fft_win, axis=axis, n=n)
+    fft_ker = xp.fft.rfft(kernel, n=n)[(slice(None), *kernel_axis_pad)]
+    return xp.fft.irfft(fft_sig * fft_ker, axis=axis, n=n)
 
 
-def _convolve_dataarray_fft_zeropad(dataarray, window, dim):
+def _convolve_dataarray_fft_zeropad(dataarray, kernel, dim):
     """FFT-based convolution with zero-padding at the boundary."""
-    xp = array_namespace(dataarray.data, window)
+    xp = array_namespace(dataarray.data, kernel)
     nsig = dataarray.sizes[dim]
-    nwin = window.size
-    nfft = nsig + nwin - 1
+    nker = kernel.size
+    nfft = nsig + nker - 1
     axis = dataarray.get_axis_num(dim)
-    convolved = _convolve_array_fft(dataarray.data, window, axis=axis, n=nfft, xp=xp)
+    convolved = _convolve_array_fft(dataarray.data, kernel, axis=axis, n=nfft, xp=xp)
     # Consistent with direct implementation and centering convention of xarray
-    start = (nwin - 1) // 2
+    start = (nker - 1) // 2
     slicer = [slice(None)] * dataarray.ndim
     slicer[axis] = slice(start, start + nsig)
     return dataarray.copy(data=convolved[tuple(slicer)])
 
 
-def _convolve_dataarray_fft_periodic(dataarray, window, dim):
+def _convolve_dataarray_fft_periodic(dataarray, kernel, dim):
     """FFT-based convolution with periodic boundary condition."""
-    xp = array_namespace(dataarray.data, window)
+    xp = array_namespace(dataarray.data, kernel)
     nsig = dataarray.sizes[dim]
-    start = (window.size - 1) // 2
+    start = (kernel.size - 1) // 2
     axis = dataarray.get_axis_num(dim)
-    convolved = _convolve_array_fft(dataarray.data, window, axis=axis, n=nsig, xp=xp)
+    convolved = _convolve_array_fft(dataarray.data, kernel, axis=axis, n=nsig, xp=xp)
     convolved = xp.roll(convolved, -start, axis=axis)
     return dataarray.copy(data=convolved)
 
 
-_CONVOLVE_METHODS = {
+_CONVOLVE_METHODS: Mapping[tuple[MethodT, BoundaryT], Callable] = {
     ("direct", "zeropad"): _convolve_dataarray_direct_zeropad,
     ("fft", "zeropad"): _convolve_dataarray_fft_zeropad,
     ("fft", "periodic"): _convolve_dataarray_fft_periodic,

--- a/src/earthkit/transforms/_convolve.py
+++ b/src/earthkit/transforms/_convolve.py
@@ -20,11 +20,7 @@ from earthkit.transforms._aggregate import how_label_rename
 from earthkit.utils.array import array_namespace
 
 
-def convolve(
-    dataarray: xr.DataArray | xr.Dataset,
-    *_args,
-    **kwargs
-):
+def convolve(dataarray: xr.DataArray | xr.Dataset, *_args, **kwargs):
     r"""Convolve an xarray.dataarray or xarray.dataset with a 1-D window along a dimension.
 
     Parameters
@@ -47,7 +43,7 @@ def convolve(
         - ``"direct"``: implementation as a windowed dot product. Preserves the
           input dtype and propagates ``NaN`` locally.
         - ``"fft"``: evaluated in the frequency domain via the convolution
-          theorem. Faster for long windows, but casts all inputs to float and
+          theorem. Fastest for longer windows. Casts all inputs to float and
           spreads ``NaN`` values across the entire convolution axis.
     how_label : str | None
         Label to append to the name of the variable in the convoluted object,
@@ -88,7 +84,7 @@ def _convolve_dataarray(
     *,
     how_boundary: Literal["zeropad"] | Literal["periodic"] = "zeropad",
     how_method: Literal["auto"] | Literal["direct"] | Literal["fft"] = "auto",
-    how_label: str = None
+    how_label: str = None,
 ):
     r"""Convolve a data array with a 1-D window along a single dimension.
 
@@ -127,7 +123,7 @@ def _convolve_dataarray(
         # FFT is float-only, so choose direct method when result has any other type
         how_method_proposed = "fft" if dataarray.dtype.kind == "f" or window.dtype.kind == "f" else "direct"
         if (how_method_proposed, how_boundary) not in _CONVOLVE_METHODS:
-            raise ValueError(
+            raise RuntimeError(
                 f"Unable to auto-select a method for input and boundary {how_boundary!r}. "
                 "Please select a method and boundary combination explicitly."
             )
@@ -147,22 +143,22 @@ def _convolve_dataarray(
 
 
 def _convolve_dataarray_direct_zeropad(dataarray, window, dim):
-    # Reverse kernel to get true convolution from dot-product
-    window = window[::-1].copy()
+    """Rolling dot product-based convolution with zero-padding at the boundary."""
+    window = window[::-1].copy()  # reverse kernel for true convolution
     k = window.size
     window_dim = f"__convolve_dim_{dim}"
     window_da = xr.DataArray(window, dims=[window_dim])
-    zero = dataarray.dtype.type(0)
-    rolled = dataarray.rolling({dim: k}, center=True).construct(window_dim, fill_value=zero)
-    result = (rolled * window_da).sum(dim=window_dim, skipna=False)
-    # Multiplying by the (unnamed) window_da drops .name; restore it
-    return result.rename(dataarray.name)
+    return (
+        dataarray.rolling({dim: k}, center=True)
+        .construct(window_dim, fill_value=dataarray.dtype.type(0))
+        .dot(window_da, dim=window_dim)
+    )
 
 
-def _convolve_array_fft(signal, window, axis, n):
+def _convolve_array_fft(signal, window, axis, n, xp):
+    """Generic FFT-based convolution."""
     if signal.dtype.kind != "f" or window.dtype.kind != "f":
         warnings.warn("FFT-based convolution casts inputs to float")
-    xp = array_namespace(signal, window)
     window_axis_pad = (xp.newaxis,) * (signal.ndim - axis - 1)
     fft_sig = xp.fft.rfft(signal, axis=axis, n=n)
     fft_win = xp.fft.rfft(window, n=n)[(slice(None), *window_axis_pad)]
@@ -170,11 +166,13 @@ def _convolve_array_fft(signal, window, axis, n):
 
 
 def _convolve_dataarray_fft_zeropad(dataarray, window, dim):
+    """FFT-based convolution with zero-padding at the boundary."""
+    xp = array_namespace(dataarray.data, window)
     nsig = dataarray.sizes[dim]
     nwin = window.size
     nfft = nsig + nwin - 1
     axis = dataarray.get_axis_num(dim)
-    convolved = _convolve_array_fft(dataarray.data, window, axis=axis, n=nfft)
+    convolved = _convolve_array_fft(dataarray.data, window, axis=axis, n=nfft, xp=xp)
     # Consistent with direct implementation and centering convention of xarray
     start = (nwin - 1) // 2
     slicer = [slice(None)] * dataarray.ndim
@@ -183,11 +181,12 @@ def _convolve_dataarray_fft_zeropad(dataarray, window, dim):
 
 
 def _convolve_dataarray_fft_periodic(dataarray, window, dim):
+    """FFT-based convolution with periodic boundary condition."""
     xp = array_namespace(dataarray.data, window)
     nsig = dataarray.sizes[dim]
     start = (window.size - 1) // 2
     axis = dataarray.get_axis_num(dim)
-    convolved = _convolve_array_fft(dataarray.data, window, axis=axis, n=nsig)
+    convolved = _convolve_array_fft(dataarray.data, window, axis=axis, n=nsig, xp=xp)
     convolved = xp.roll(convolved, -start, axis=axis)
     return dataarray.copy(data=convolved)
 

--- a/src/earthkit/transforms/temporal/__init__.py
+++ b/src/earthkit/transforms/temporal/__init__.py
@@ -42,6 +42,7 @@ from ._aggregate import (
     std,
     sum,
 )
+from ._convolve import convolve
 from ._rates import accumulation_to_rate, deaccumulate
 
 __all__ = [
@@ -70,4 +71,5 @@ __all__ = [
     "standardise_time",
     "accumulation_to_rate",
     "deaccumulate",
+    "convolve",
 ]

--- a/src/earthkit/transforms/temporal/_convolve.py
+++ b/src/earthkit/transforms/temporal/_convolve.py
@@ -1,0 +1,68 @@
+# Copyright 2026-, European Centre for Medium Range Weather Forecasts.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Literal
+
+import xarray as xr
+from earthkit.utils.decorators import format_handler
+
+from earthkit.transforms import _tools
+from earthkit.transforms._convolve import convolve as _convolve
+
+
+@format_handler()
+def convolve(
+    dataarray: xr.Dataset | xr.DataArray,
+    window: "array_like",
+    *_args,
+    time_dim: str | None = None,
+    how_boundary: Literal["zeropad"] = "zeropad",
+    **kwargs,
+) -> xr.Dataset | xr.DataArray:
+    """Convolution along the time dimension.
+
+    Parameters
+    ----------
+    dataarray : xarray.DataArray | xarray.Dataset
+        First input to the convolution.
+    window : array_like
+        Second input to the convolution, a 1-D kernel.
+    time_dim : str
+        Name of the time dimension, or coordinate, in the xarray object,
+        default behaviour is to deduce time dimension from
+        attributes of coordinates, then fall back to `"time"`.
+    how_boundary : {"zeropad", "periodic"}, default: "zeropad"
+        How the signal is extended where the window overhangs:
+
+        - ``"zeropad"``: the signal is extended with zeros.
+    how_method : {"auto", "direct", "fft"}, default: "auto"
+        How the convolution is evaluated:
+
+        - ``"auto"``: automatically select a method based on the inputs.
+        - ``"direct"``: implementation as a windowed dot product. Preserves the
+          input dtype and propagates ``NaN`` locally.
+        - ``"fft"``: evaluated in the frequency domain via the convolution
+          theorem. Fastest for longer windows. Casts all inputs to float and
+          spreads ``NaN`` values across the time axis.
+    how_label : str | None
+        Label to append to the name of the variable in the convoluted object,
+        default is nothing.
+
+    Returns
+    -------
+    xarray.DataArray | xarray.Dataset
+        dataarray convolved with the given window along the time dimension.
+    """
+    kwargs["dim"] = _tools.get_dim_key(dataarray, "t") if time_dim is None else time_dim
+    kwargs["how_boundary"] = how_boundary
+    return _convolve(dataarray, window, *_args, **kwargs)

--- a/src/earthkit/transforms/temporal/_convolve.py
+++ b/src/earthkit/transforms/temporal/_convolve.py
@@ -11,24 +11,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Literal
+from typing import TypeVar
 
 import xarray as xr
 from earthkit.utils.decorators import format_handler
+from numpy.typing import ArrayLike
 
 from earthkit.transforms import _tools
 from earthkit.transforms._convolve import convolve as _convolve
 
+T = TypeVar("T", xr.Dataset, xr.DataArray)
+
 
 @format_handler()
 def convolve(
-    dataarray: xr.Dataset | xr.DataArray,
-    window: "array_like",
-    *_args,
+    dataarray: T,
+    window: ArrayLike,
     time_dim: str | None = None,
     remove_partial_periods: bool = False,
     **kwargs,
-) -> xr.Dataset | xr.DataArray:
+) -> T:
     """Centred convolution along the time dimension.
 
     Time series are zero-padded at the boundaries.
@@ -47,27 +49,27 @@ def convolve(
         How the convolution is evaluated:
 
         - ``"auto"``: automatically select a method based on the inputs.
-        - ``"direct"``: implementation as a windowed dot product. Preserves the
-          input dtype and propagates ``NaN`` locally.
+        - ``"direct"``: implementation as a windowed dot product. Propagates
+          ``NaN`` values locally.
         - ``"fft"``: evaluated in the frequency domain via the convolution
           theorem. Fastest for longer windows. Casts all inputs to float and
           spreads ``NaN`` values across the time axis.
-    how_label : str | None
+    how_label : str | None, default: None
         Label to append to the name of the variable in the convoluted object,
         default is nothing.
-    remove_partial_periods : bool
+    remove_partial_periods : bool, default: False
         If True, remove time steps affected by padding at the start and end.
-        Default is False.
+    **kwargs
+        Keyword arguments passed to :func:`earthkit.transforms.convolve`.
 
     Returns
     -------
-    xarray.DataArray | xarray.Dataset
-        dataarray convolved with the given window along the time dimension.
+    xarray.DataArray or xarray.Dataset (as provided)
     """
     dim = _tools.get_dim_key(dataarray, "t") if time_dim is None else time_dim
     kwargs["dim"] = dim
     kwargs["how_boundary"] = "zeropad"
-    result = _convolve(dataarray, window, *_args, **kwargs)
+    result = _convolve(dataarray, window, **kwargs)
     if remove_partial_periods and (k := len(window)) > 1:
         start = k // 2
         end = -((k - 1) // 2) or None  # avoid -0 for k==2

--- a/src/earthkit/transforms/temporal/_convolve.py
+++ b/src/earthkit/transforms/temporal/_convolve.py
@@ -13,6 +13,7 @@
 
 from typing import TypeVar
 
+import numpy as np
 import xarray as xr
 from earthkit.utils.decorators import format_handler
 from numpy.typing import ArrayLike
@@ -20,17 +21,14 @@ from numpy.typing import ArrayLike
 from earthkit.transforms import _tools
 from earthkit.transforms._convolve import convolve as _convolve
 
-T = TypeVar("T", xr.Dataset, xr.DataArray)
-
-
 @format_handler()
 def convolve(
-    dataarray: T,
-    window: ArrayLike,
+    dataarray: xr.Dataset | xr.DataArray,
+    window: np.typing.ArrayLike,
     time_dim: str | None = None,
     remove_partial_periods: bool = False,
     **kwargs,
-) -> T:
+) -> xr.Dataset | xr.DataArray:
     """Centred convolution along the time dimension.
 
     Time series are zero-padded at the boundaries.
@@ -70,7 +68,7 @@ def convolve(
     kwargs["dim"] = dim
     kwargs["how_boundary"] = "zeropad"
     result = _convolve(dataarray, window, **kwargs)
-    if remove_partial_periods and (k := len(window)) > 1:
+    if remove_partial_periods and (k := np.asarray(window).size) > 1:
         start = k // 2
         end = -((k - 1) // 2) or None  # avoid -0 for k==2
         result = result.isel({dim: slice(start, end)})

--- a/src/earthkit/transforms/temporal/_convolve.py
+++ b/src/earthkit/transforms/temporal/_convolve.py
@@ -26,10 +26,12 @@ def convolve(
     window: "array_like",
     *_args,
     time_dim: str | None = None,
-    how_boundary: Literal["zeropad"] = "zeropad",
+    remove_partial_periods: bool = False,
     **kwargs,
 ) -> xr.Dataset | xr.DataArray:
-    """Convolution along the time dimension.
+    """Centred convolution along the time dimension.
+
+    Time series are zero-padded at the boundaries.
 
     Parameters
     ----------
@@ -41,10 +43,6 @@ def convolve(
         Name of the time dimension, or coordinate, in the xarray object,
         default behaviour is to deduce time dimension from
         attributes of coordinates, then fall back to `"time"`.
-    how_boundary : {"zeropad", "periodic"}, default: "zeropad"
-        How the signal is extended where the window overhangs:
-
-        - ``"zeropad"``: the signal is extended with zeros.
     how_method : {"auto", "direct", "fft"}, default: "auto"
         How the convolution is evaluated:
 
@@ -57,12 +55,21 @@ def convolve(
     how_label : str | None
         Label to append to the name of the variable in the convoluted object,
         default is nothing.
+    remove_partial_periods : bool
+        If True, remove time steps affected by padding at the start and end.
+        Default is False.
 
     Returns
     -------
     xarray.DataArray | xarray.Dataset
         dataarray convolved with the given window along the time dimension.
     """
-    kwargs["dim"] = _tools.get_dim_key(dataarray, "t") if time_dim is None else time_dim
-    kwargs["how_boundary"] = how_boundary
-    return _convolve(dataarray, window, *_args, **kwargs)
+    dim = _tools.get_dim_key(dataarray, "t") if time_dim is None else time_dim
+    kwargs["dim"] = dim
+    kwargs["how_boundary"] = "zeropad"
+    result = _convolve(dataarray, window, *_args, **kwargs)
+    if remove_partial_periods and (k := len(window)) > 1:
+        start = k // 2
+        end = -((k - 1) // 2) or None  # avoid -0 for k==2
+        result = result.isel({dim: slice(start, end)})
+    return result

--- a/tests/test_20_convolve.py
+++ b/tests/test_20_convolve.py
@@ -100,10 +100,11 @@ def test_convolve_raises_for_empty_window(data_1d):
         convolve(data_1d, [], "t")
 
 
-def test_convolve_direct_convolution_preserves_integer_dtype():
+@pytest.mark.parametrize("how_method", ["auto", "direct"])
+def test_convolve_preserves_integer_dtype(how_method):
     data = xr.DataArray(np.arange(9), dims=["t"])
     window = np.array([1, 1, 1])
-    result = convolve(data, window, "t", how_method="direct", how_boundary="zeropad")
+    result = convolve(data, window, "t", how_method=how_method, how_boundary="zeropad")
     assert result.dtype.kind == "i"
     expected = np.array([1, 3, 6, 9, 12, 15, 18, 21, 15])
     np.testing.assert_array_equal(result.values, expected)

--- a/tests/test_20_convolve.py
+++ b/tests/test_20_convolve.py
@@ -93,7 +93,7 @@ def test_convolve_along_dim(how_method, how_boundary, dim, data_3d, window):
 
 @pytest.mark.parametrize("how_method", ["auto", "direct"])
 def test_convolve_preserves_integer_dtype_for_all_integer_input(how_method):
-    data = xr.DataArray(np.arange(9), dims=["t"], dtype=int)
+    data = xr.DataArray(np.arange(9, dtype=int), dims=["t"])
     window = np.array([1, 1, 1], dtype=int)
     result = convolve(data, window, "t", how_method=how_method, how_boundary="zeropad")
     assert result.dtype.kind == "i"

--- a/tests/test_20_convolve.py
+++ b/tests/test_20_convolve.py
@@ -4,7 +4,6 @@ import xarray as xr
 
 from earthkit.transforms._convolve import convolve
 
-
 VALID_COMBINATIONS = [
     ("direct", "zeropad"),
     ("fft", "zeropad"),
@@ -93,9 +92,9 @@ def test_convolve_along_dim(how_method, how_boundary, dim, data_3d, window):
 
 
 @pytest.mark.parametrize("how_method", ["auto", "direct"])
-def test_convolve_preserves_integer_dtype(how_method):
-    data = xr.DataArray(np.arange(9), dims=["t"])
-    window = np.array([1, 1, 1])
+def test_convolve_preserves_integer_dtype_for_all_integer_input(how_method):
+    data = xr.DataArray(np.arange(9), dims=["t"], dtype=int)
+    window = np.array([1, 1, 1], dtype=int)
     result = convolve(data, window, "t", how_method=how_method, how_boundary="zeropad")
     assert result.dtype.kind == "i"
     expected = np.array([1, 3, 6, 9, 12, 15, 18, 21, 15])
@@ -118,7 +117,7 @@ def test_convolve_how_label_none_leaves_name_unchanged(how_method, how_boundary,
 
 def test_convolve_raises_for_multidimensional_window(data_1d):
     with pytest.raises(ValueError, match="1-dimensional"):
-        convolve(data_1d, np.ones((2, 2)), "t")
+        convolve(data_1d, np.ones((2, 2), dtype=float), "t")
 
 
 def test_convolve_raises_for_empty_window(data_1d):

--- a/tests/test_20_convolve.py
+++ b/tests/test_20_convolve.py
@@ -67,9 +67,7 @@ def test_convolve_fft_periodic_matches_analytical_sinusoid():
     # Same frequency, rescaled and phase-shifted by the window's frequency
     # response plus a phase term from the centering roll
     response = np.fft.rfft(window, n=n)[freq]
-    expected = np.abs(response) * np.cos(
-        2 * np.pi * freq * t / n + np.angle(response) + 2 * np.pi * freq * start / n
-    )
+    expected = np.abs(response) * np.cos(2 * np.pi * freq * t / n + np.angle(response) + 2 * np.pi * freq * start / n)
     result = convolve(data, window, "t", how_method="fft", how_boundary="periodic")
     np.testing.assert_allclose(result.values, expected, atol=1e-8)
 

--- a/tests/test_20_convolve.py
+++ b/tests/test_20_convolve.py
@@ -41,7 +41,8 @@ def test_convolve_dataset_matches_dataarrays(how_method, how_boundary, data_1d, 
 
 
 @pytest.mark.parametrize("how_method, how_boundary", VALID_COMBINATIONS)
-def test_convolve_matches_impulse_response(how_method, how_boundary, window):
+def test_convolve_matches_impulse_response(how_method, how_boundary):
+    window = np.array([1.0, 2.0, 3.0])
     impulse_index = 5
     impulse = np.zeros(11)
     impulse[impulse_index] = 1.0
@@ -56,8 +57,25 @@ def test_convolve_matches_impulse_response(how_method, how_boundary, window):
     np.testing.assert_allclose(result.values, expected, atol=1e-8)
 
 
+def test_convolve_fft_periodic_matches_analytical_sinusoid():
+    n = 19
+    freq = 3
+    window = np.array([1.0, 1.0, 1.0])
+    start = (window.size - 1) // 2
+    t = np.arange(n)
+    data = xr.DataArray(np.cos(2 * np.pi * freq * t / n), dims=["t"])
+    # Same frequency, rescaled and phase-shifted by the window's frequency
+    # response plus a phase term from the centering roll
+    response = np.fft.rfft(window, n=n)[freq]
+    expected = np.abs(response) * np.cos(
+        2 * np.pi * freq * t / n + np.angle(response) + 2 * np.pi * freq * start / n
+    )
+    result = convolve(data, window, "t", how_method="fft", how_boundary="periodic")
+    np.testing.assert_allclose(result.values, expected, atol=1e-8)
+
+
 @pytest.mark.parametrize("window_values", ([1.0, 2.0, 3.0], [1.0, 2.0, 3.0, 4.0]))
-def test_convolve_zeropad_direct_and_fft_agree(data_1d, window_values):
+def test_convolve_direct_and_fft_agree_for_zeropad(data_1d, window_values):
     window = np.array(window_values)
     direct = convolve(data_1d, window, "t", how_method="direct", how_boundary="zeropad")
     fft = convolve(data_1d, window, "t", how_method="fft", how_boundary="zeropad")
@@ -74,6 +92,16 @@ def test_convolve_along_dim(how_method, how_boundary, dim, data_3d, window):
     selection = {d: 0 for d in data_3d.dims if d != dim}
     expected_1d = convolve(data_3d.isel(selection), window, dim, how_method=how_method, how_boundary=how_boundary)
     xr.testing.assert_allclose(result.isel(selection), expected_1d, atol=1e-8)
+
+
+@pytest.mark.parametrize("how_method", ["auto", "direct"])
+def test_convolve_preserves_integer_dtype(how_method):
+    data = xr.DataArray(np.arange(9), dims=["t"])
+    window = np.array([1, 1, 1])
+    result = convolve(data, window, "t", how_method=how_method, how_boundary="zeropad")
+    assert result.dtype.kind == "i"
+    expected = np.array([1, 3, 6, 9, 12, 15, 18, 21, 15])
+    np.testing.assert_array_equal(result.values, expected)
 
 
 @pytest.mark.parametrize("how_method, how_boundary", VALID_COMBINATIONS)
@@ -98,13 +126,3 @@ def test_convolve_raises_for_multidimensional_window(data_1d):
 def test_convolve_raises_for_empty_window(data_1d):
     with pytest.raises(ValueError, match="non-empty"):
         convolve(data_1d, [], "t")
-
-
-@pytest.mark.parametrize("how_method", ["auto", "direct"])
-def test_convolve_preserves_integer_dtype(how_method):
-    data = xr.DataArray(np.arange(9), dims=["t"])
-    window = np.array([1, 1, 1])
-    result = convolve(data, window, "t", how_method=how_method, how_boundary="zeropad")
-    assert result.dtype.kind == "i"
-    expected = np.array([1, 3, 6, 9, 12, 15, 18, 21, 15])
-    np.testing.assert_array_equal(result.values, expected)

--- a/tests/test_20_convolve.py
+++ b/tests/test_20_convolve.py
@@ -57,7 +57,7 @@ def test_convolve_matches_impulse_response(how_method, how_boundary, window):
 
 
 @pytest.mark.parametrize("window_values", ([1.0, 2.0, 3.0], [1.0, 2.0, 3.0, 4.0]))
-def test_zeropad_direct_and_fft_agree(data_1d, window_values):
+def test_convolve_zeropad_direct_and_fft_agree(data_1d, window_values):
     window = np.array(window_values)
     direct = convolve(data_1d, window, "t", how_method="direct", how_boundary="zeropad")
     fft = convolve(data_1d, window, "t", how_method="fft", how_boundary="zeropad")
@@ -77,20 +77,30 @@ def test_convolve_along_dim(how_method, how_boundary, dim, data_3d, window):
 
 
 @pytest.mark.parametrize("how_method, how_boundary", VALID_COMBINATIONS)
-def test_how_label_renames_dataarray(how_method, how_boundary, data_1d, window):
+def test_convolve_how_label_renames_dataarray(how_method, how_boundary, data_1d, window):
     named = data_1d.rename("temperature")
     result = convolve(named, window, "t", how_method=how_method, how_boundary=how_boundary, how_label="smoothed")
     assert result.name == "temperature_smoothed"
 
 
 @pytest.mark.parametrize("how_method, how_boundary", VALID_COMBINATIONS)
-def test_how_label_none_leaves_name_unchanged(how_method, how_boundary, data_1d, window):
+def test_convolve_how_label_none_leaves_name_unchanged(how_method, how_boundary, data_1d, window):
     named = data_1d.rename("temperature")
     result = convolve(named, window, "t", how_method=how_method, how_boundary=how_boundary)
     assert result.name == "temperature"
 
 
-def test_direct_convolution_preserves_integer_dtype():
+def test_convolve_raises_for_multidimensional_window(data_1d):
+    with pytest.raises(ValueError, match="1-dimensional"):
+        convolve(data_1d, np.ones((2, 2)), "t")
+
+
+def test_convolve_raises_for_empty_window(data_1d):
+    with pytest.raises(ValueError, match="non-empty"):
+        convolve(data_1d, [], "t")
+
+
+def test_convolve_direct_convolution_preserves_integer_dtype():
     data = xr.DataArray(np.arange(9), dims=["t"])
     window = np.array([1, 1, 1])
     result = convolve(data, window, "t", how_method="direct", how_boundary="zeropad")

--- a/tests/test_21_convolve.py
+++ b/tests/test_21_convolve.py
@@ -1,0 +1,99 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from earthkit.transforms._convolve import convolve
+
+
+VALID_COMBINATIONS = [
+    ("direct", "zeropad"),
+    ("fft", "zeropad"),
+    ("fft", "periodic"),
+]
+
+
+@pytest.fixture
+def window() -> np.ndarray:
+    return np.array([1.0, 2.0, 3.0])
+
+
+@pytest.fixture
+def data_1d() -> xr.DataArray:
+    return xr.DataArray(np.array([1.0, 3.0, 2.0, 5.0, 4.0, 6.0, 2.0, 8.0, 1.0]), dims=["t"])
+
+
+@pytest.fixture
+def data_3d(data_1d) -> xr.DataArray:
+    base_a = xr.DataArray([1.0, -2.0, 0.5], dims=["a"])
+    base_b = xr.DataArray([1.0, -1.0, 3.0], dims=["b"])
+    return (data_1d * base_a * base_b).transpose("a", "t", "b")
+
+
+@pytest.mark.parametrize("how_method, how_boundary", VALID_COMBINATIONS)
+def test_convolve_dataset_matches_dataarrays(how_method, how_boundary, data_1d, window):
+    dataset = xr.Dataset({"temperature": data_1d, "pressure": data_1d * 2})
+    result = convolve(dataset, window, "t", how_method=how_method, how_boundary=how_boundary)
+    assert isinstance(result, xr.Dataset)
+    assert set(result.data_vars) == set(dataset.data_vars)
+    for var in dataset.data_vars:
+        expected = convolve(dataset[var], window, "t", how_method=how_method, how_boundary=how_boundary)
+        xr.testing.assert_allclose(result[var], expected, atol=1e-8)
+
+
+@pytest.mark.parametrize("how_method, how_boundary", VALID_COMBINATIONS)
+def test_convolve_matches_impulse_response(how_method, how_boundary, window):
+    impulse_index = 5
+    impulse = np.zeros(11)
+    impulse[impulse_index] = 1.0
+    impulse_data = xr.DataArray(impulse, dims=["t"])
+    # Analytical solution: convolving an impulse with a window just places
+    # the window itself, starting at (impulse_index - start).
+    expected = np.zeros_like(impulse_data)
+    lo = impulse_index - (window.size - 1) // 2
+    expected[lo : lo + window.size] = window
+    result = convolve(impulse_data, window, "t", how_method=how_method, how_boundary=how_boundary)
+    assert result.dims == impulse_data.dims
+    np.testing.assert_allclose(result.values, expected, atol=1e-8)
+
+
+@pytest.mark.parametrize("window_values", ([1.0, 2.0, 3.0], [1.0, 2.0, 3.0, 4.0]))
+def test_zeropad_direct_and_fft_agree(data_1d, window_values):
+    window = np.array(window_values)
+    direct = convolve(data_1d, window, "t", how_method="direct", how_boundary="zeropad")
+    fft = convolve(data_1d, window, "t", how_method="fft", how_boundary="zeropad")
+    xr.testing.assert_allclose(direct, fft, atol=1e-8)
+
+
+@pytest.mark.parametrize("how_method, how_boundary", VALID_COMBINATIONS)
+@pytest.mark.parametrize("dim", ["a", "t", "b"])
+def test_convolve_along_dim(how_method, how_boundary, dim, data_3d, window):
+    result = convolve(data_3d, window, dim, how_method=how_method, how_boundary=how_boundary)
+    assert result.dims == data_3d.dims
+    assert result.shape == data_3d.shape
+    # Check result for first element
+    selection = {d: 0 for d in data_3d.dims if d != dim}
+    expected_1d = convolve(data_3d.isel(selection), window, dim, how_method=how_method, how_boundary=how_boundary)
+    xr.testing.assert_allclose(result.isel(selection), expected_1d, atol=1e-8)
+
+
+@pytest.mark.parametrize("how_method, how_boundary", VALID_COMBINATIONS)
+def test_how_label_renames_dataarray(how_method, how_boundary, data_1d, window):
+    named = data_1d.rename("temperature")
+    result = convolve(named, window, "t", how_method=how_method, how_boundary=how_boundary, how_label="smoothed")
+    assert result.name == "temperature_smoothed"
+
+
+@pytest.mark.parametrize("how_method, how_boundary", VALID_COMBINATIONS)
+def test_how_label_none_leaves_name_unchanged(how_method, how_boundary, data_1d, window):
+    named = data_1d.rename("temperature")
+    result = convolve(named, window, "t", how_method=how_method, how_boundary=how_boundary)
+    assert result.name == "temperature"
+
+
+def test_direct_convolution_preserves_integer_dtype():
+    data = xr.DataArray(np.arange(9), dims=["t"])
+    window = np.array([1, 1, 1])
+    result = convolve(data, window, "t", how_method="direct", how_boundary="zeropad")
+    assert result.dtype.kind == "i"
+    expected = np.array([1, 3, 6, 9, 12, 15, 18, 21, 15])
+    np.testing.assert_array_equal(result.values, expected)

--- a/tests/test_30_temporal_convolve.py
+++ b/tests/test_30_temporal_convolve.py
@@ -35,3 +35,25 @@ def test_temporal_convolve(in_data, expected_return_type):
         # Test dataarray from here
         convolved_data = convolved_data["2t"]
     assert convolved_data.dims == ("forecast_reference_time", "latitude", "longitude")
+
+
+@pytest.fixture
+def time_series():
+    return xr.DataArray(np.ones(20, dtype=float), dims=["time"], coords={"time": np.arange(20)})
+
+
+@pytest.mark.parametrize("k", [1, 2, 3, 4, 5, 6])
+def test_temporal_convolve_remove_partial_periods_bounds(time_series, k):
+    window = np.ones(k, dtype=float) / k  # normalised
+    result = temporal.convolve(time_series, window, remove_partial_periods=True)
+    assert result.sizes["time"] == time_series.sizes["time"] - k + 1
+    np.testing.assert_array_almost_equal(result.values, 1.0)
+
+
+@pytest.mark.parametrize("k", [1, 2, 3, 4, 5, 6])
+def test_temporal_convolve_keeps_full_bounds_by_default(time_series, k):
+    window = np.ones(k)
+    result = temporal.convolve(time_series, window, time_dim="time")
+    assert result.sizes["time"] == time_series.sizes["time"]
+    assert result.time.values[0] == time_series.time.values[0]
+    assert result.time.values[-1] == time_series.time.values[-1]

--- a/tests/test_30_temporal_convolve.py
+++ b/tests/test_30_temporal_convolve.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-
 import xarray as xr
 
 from earthkit import data as ek_data
@@ -52,7 +51,7 @@ def test_temporal_convolve_remove_partial_periods_bounds(time_series, k):
 
 @pytest.mark.parametrize("k", [1, 2, 3, 4, 5, 6])
 def test_temporal_convolve_keeps_full_bounds_by_default(time_series, k):
-    window = np.ones(k)
+    window = np.ones(k, dtype=float)
     result = temporal.convolve(time_series, window, time_dim="time")
     assert result.sizes["time"] == time_series.sizes["time"]
     assert result.time.values[0] == time_series.time.values[0]

--- a/tests/test_30_temporal_convolve.py
+++ b/tests/test_30_temporal_convolve.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+import xarray as xr
+
+from earthkit import data as ek_data
+from earthkit.transforms import temporal
+from earthkit.transforms._tools import earthkit_remote_test_data_file
+
+# Use caching for speedy repeats
+ek_data.settings.set("cache-policy", "user")
+
+
+def get_data(srcfile: str = "era5_temperature_europe_2015.grib"):
+    remote_era5_file = earthkit_remote_test_data_file(srcfile)
+    return ek_data.from_source("url", remote_era5_file)
+
+
+@pytest.mark.parametrize(
+    "in_data, expected_return_type",
+    (
+        [get_data(), xr.Dataset],
+        [get_data().to_xarray(), xr.Dataset],
+        [get_data().to_xarray()["2t"], xr.DataArray],
+    ),
+)
+def test_temporal_convolve(in_data, expected_return_type):
+    window = np.asarray([1.0, 1.0, 2.0, 1.0, 1.0])
+    convolved_data = temporal.convolve(in_data, window)
+    assert isinstance(convolved_data, expected_return_type)
+    if expected_return_type == xr.DataArray:
+        assert "2t" == convolved_data.name
+    else:
+        assert "2t" in convolved_data
+        # Test dataarray from here
+        convolved_data = convolved_data["2t"]
+    assert convolved_data.dims == ("forecast_reference_time", "latitude", "longitude")


### PR DESCRIPTION
### Description

1-dimensional centred convolution along an axis.

- [`earthkit.transforms.convolve()`](https://earthkit-transforms--121.org.readthedocs.build/en/121/autodocs/generated/earthkit.transforms/earthkit.transforms.convolve.html) (general implementation).
- [`earthkit.transforms.temporal.convolve()`](https://earthkit-transforms--121.org.readthedocs.build/en/121/autodocs/generated/temporal/earthkit.transforms.temporal.convolve.html) (specialised implementation for time series with zero-padded boundary set fixed and option to remove partial periods)

3 implementations to carry out the convolution are included:

- Direct (rolling dot product) with zero-padding
- FFT with zero-padding
- FFT with periodic boundary

An `"auto"` selection for the method is available and set as the default, but the logic could be more refined. At the moment, it always picks FFT unless the output is non-float or the input is chunked along the time dimension. The direct method is not an ideal fallback though as it currently lacks a periodic implementation.

### Follow-up work

It would be nice to provide low- and high-pass filter functions based on convolution for convenience. Users could specify filter properties and corresponding convolution kernels are then automatically constructed based on the specification. This would work for time series (filtering by frequencies, padded boundary), climatologies (filtering by frequencies, periodic boundary; see also #62 though the issue asks for spectral truncation only), and along longitude if the input covers 360° (filtering by wavenumber, periodic boundary).

Lower priority (for me):

- It would be easy to provide cross-correlation too. It's the same as convolution but the window is applied the other way around. If the window is symmetric, both are identical.
- Coordinate checks. The window is defined without coordinates and applied without any checks on the time series coordinates. The convolution only really makes sense if the coordinates are regularly spaced. This could be checked and at least a warning raised telling the user to resample first.
- The FFT functions are part of the array api, so this _should_ work for many backends. However, I've only tested numpy and dask so far.
- Scipy also offers symmetric boundary conditions and padding with arbitrary values (not just zero). I don't have a use case for these at the moment, but they could be an easy addition.
- Improved auto-selection of the method and more information for users if it fails. Scipy also includes expected performance as a criterion but that seems a bit more involved. NaNs in the input could be a criterion as well.
- 2D convolution for smoothing of spatial fields. This can get complicated depending on the grid geometry.

### Overlap with rolling_reduce

The direct implementation of convolution is technically already covered by rolling_reduce. E.g., the example from the how-to notebook could also be achieved with

```py
def weighted_average(values, axis):
    return np.average(values, axis=axis, weights=window)

rolling_smoothed = ekt.temporal.rolling_reduce(
    ds, window_length=29, how_reduce=weighted_average, center=True
)
```

(technically, this is cross correlation, but the window is symmetric so it doesn't matter)


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
