### PR TITLE
Raise on all_touched for irregular grids

### DIFF
--- a/src/earthkit/transforms/spatial/_aggregate.py
+++ b/src/earthkit/transforms/spatial/_aggregate.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 import functools
-import logging
 import typing as T
 from copy import deepcopy
 
@@ -29,8 +28,6 @@ from earthkit.transforms._tools import (
     get_spatial_info,
     standard_weights,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def _transform_from_latlon(lat, lon):
@@ -668,12 +665,16 @@ def _reduce_dataarray_as_xarray(
     spatial_info = get_spatial_info(dataarray, lat_key=lat_key, lon_key=lon_key)
     # Get spatial info required by mask functions:
     mask_kwargs = {**mask_kwargs, **{key: spatial_info[key] for key in ["lat_key", "lon_key", "regular"]}}
-    # All touched only valid for rasterize method
+    requested_all_touched = all_touched or mask_kwargs.get("all_touched", False)
+    if not spatial_info["regular"] and requested_all_touched and mask_arrays is None and geodataframe is not None:
+        raise ValueError(
+            "all_touched=True is not supported for irregular grids. Use all_touched=False, provide a regular "
+            "contiguous grid, or precompute suitable masks."
+        )
+
+    # All touched is only valid for the rasterize method.
     if spatial_info["regular"]:
         mask_kwargs.setdefault("all_touched", all_touched)
-    else:
-        if all_touched:
-            logger.warning("all_touched only valid for regular data, ignoring")
     spatial_dims = spatial_info.get("spatial_dims")
 
     reduce_dims = spatial_dims + extra_reduce_dims

--- a/tests/test_30_spatial.py
+++ b/tests/test_30_spatial.py
@@ -222,6 +222,11 @@ def create_test_geodataframe():
     return gpd.GeoDataFrame(geometry=polygons, index=[1])
 
 
+def create_local_geodataframe():
+    polygon = Polygon([(0.4, 0.4), (0.4, 1.1), (1.1, 1.1), (1.1, 0.4)])
+    return gpd.GeoDataFrame(geometry=[polygon])
+
+
 def test_reduce_mean():
     dataarray = create_test_dataarray()
     result = _spatial._reduce_dataarray_as_xarray(dataarray, how="mean")
@@ -325,6 +330,45 @@ def test_spatial_reduce_with_shapely_geodataframe_local():
     result = _spatial._reduce_dataarray_as_xarray(create_test_dataarray(), geodataframe=geodataframe, how="mean")
     assert isinstance(result, xr.DataArray)
     assert "index" in result.dims
+
+
+def test_spatial_reduce_rejects_all_touched_for_irregular_grid():
+    dataarray = xr.DataArray(
+        np.arange(9).reshape(3, 3),
+        dims=("latitude", "longitude"),
+        coords={"latitude": [0.0, 1.0, 3.0], "longitude": [0.0, 1.0, 3.0]},
+    )
+
+    with pytest.raises(ValueError, match="all_touched=True is not supported for irregular grids"):
+        spatial.reduce(dataarray, create_local_geodataframe(), all_touched=True)
+
+
+def test_spatial_reduce_all_touched_false_for_irregular_grid():
+    dataarray = xr.DataArray(
+        np.arange(9).reshape(3, 3),
+        dims=("latitude", "longitude"),
+        coords={"latitude": [0.0, 1.0, 3.0], "longitude": [0.0, 1.0, 3.0]},
+    )
+
+    result = spatial.reduce(dataarray, create_local_geodataframe(), all_touched=False)
+
+    assert result.item() == 4
+
+
+@pytest.mark.skipif(
+    not rasterio_available,
+    reason="rasterio is not available",
+)
+def test_spatial_reduce_all_touched_for_regular_grid():
+    dataarray = xr.DataArray(
+        np.arange(9).reshape(3, 3),
+        dims=("latitude", "longitude"),
+        coords={"latitude": [0.0, 1.0, 2.0], "longitude": [0.0, 1.0, 2.0]},
+    )
+
+    result = spatial.reduce(dataarray, create_local_geodataframe(), all_touched=True)
+
+    assert result.item() == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- raise a clear error instead of silently ignoring `all_touched=True` when `spatial.reduce` would create a mask for an irregular grid
- retain centre-point reduction for irregular grids with `all_touched=False`
- retain rasterized touched-cell reduction for regular grids

## Compatibility
This changes an unsupported combination from a warning and centre-point result to `ValueError`. Callers can use `all_touched=False`, use a regular contiguous grid, or supply suitable precomputed masks.