### PR TITLE
Feature/reusable spatial masks

### DIFF
--- a/docs/source/concepts/spatial.rst
+++ b/docs/source/concepts/spatial.rst
@@ -25,6 +25,21 @@ parameter can be used to specify the aggregation method. The default is `mean`.
       :no-index:
 
 
+Reusing polygon masks
+^^^^^^^^^^^^^^^^^^^^^
+For repeated reductions on the same grid and polygons, build the masks once with
+:func:`shapes_to_masks` and pass them to :func:`reduce` with ``mask_arrays``.
+The masks retain the GeoDataFrame index, or a column selected with ``mask_dim``:
+
+.. code-block:: python
+
+    masks = ekt.spatial.shapes_to_masks(
+        regions, data, mask_dim="region_name", all_touched=True
+    )
+    daily_mean = ekt.spatial.reduce(today, mask_arrays=masks)
+    next_daily_mean = ekt.spatial.reduce(tomorrow, mask_arrays=masks)
+
+
 Using a bounding box instead of a geometry
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/earthkit/transforms/spatial/__init__.py
+++ b/src/earthkit/transforms/spatial/__init__.py
@@ -16,6 +16,6 @@
 Typically this is done with an xarray representation of data and a geopandas representation of geometries.
 """
 
-from ._aggregate import mask, reduce
+from ._aggregate import mask, reduce, shapes_to_masks
 
-__all__ = ["mask", "reduce"]
+__all__ = ["mask", "reduce", "shapes_to_masks"]

--- a/src/earthkit/transforms/spatial/_aggregate.py
+++ b/src/earthkit/transforms/spatial/_aggregate.py
@@ -32,6 +32,8 @@ from earthkit.transforms._tools import (
 
 logger = logging.getLogger(__name__)
 
+_MASK_DIM_ATTR = "_earthkit_mask_dim"
+
 
 def _transform_from_latlon(lat, lon):
     """Return an Affine transformation of input 1D arrays of lat and lon.
@@ -177,6 +179,19 @@ def _array_mask_iterator(mask_arrays):
         yield mask_array > 0
 
 
+def _mask_arrays_dim_index(mask_arrays: list[xr.DataArray]) -> pd.Index | None:
+    """Return labels attached by :func:`shapes_to_masks`, if present."""
+    mask_dims = {mask_array.attrs.get(_MASK_DIM_ATTR) for mask_array in mask_arrays}
+    if len(mask_dims) != 1:
+        return None
+
+    mask_dim = mask_dims.pop()
+    if mask_dim is None or any(mask_dim not in mask_array.coords for mask_array in mask_arrays):
+        return None
+
+    return pd.Index([mask_array.coords[mask_dim].item() for mask_array in mask_arrays], name=mask_dim)
+
+
 def _shape_mask_iterator(shapes, target, regular=True, **kwargs):
     """Iterate over shape mask methods."""
     if isinstance(shapes, gpd.GeoDataFrame):
@@ -190,7 +205,13 @@ def _shape_mask_iterator(shapes, target, regular=True, **kwargs):
         yield shape_da
 
 
-def shapes_to_masks(shapes: gpd.GeoDataFrame | list[gpd.GeoDataFrame], target, regular=True, **kwargs):
+def shapes_to_masks(
+    shapes: gpd.GeoDataFrame | list[gpd.GeoDataFrame],
+    target: xr.Dataset | xr.DataArray,
+    regular: bool = True,
+    mask_dim: str | None | T.Dict[str, T.Any] = None,
+    **kwargs,
+) -> list[xr.DataArray]:
     """Create a list of masked dataarrays, if possible use the shape_mask_iterator.
 
     Parameters
@@ -202,6 +223,11 @@ def shapes_to_masks(shapes: gpd.GeoDataFrame | list[gpd.GeoDataFrame], target, r
 
     regular :
         If True, data is on a regular grid so use rasterize method, if False use mask_contains_points
+    mask_dim :
+        Labels to attach to masks created from a GeoDataFrame. This follows the
+        same rules as :func:`reduce`: a column name uses that column's values,
+        otherwise the GeoDataFrame index is used. The labels are retained when
+        the masks are passed to :func:`reduce`.
     all_touched :
         If True, all pixels touched by geometries will be considered in,
         if False, only pixels whose center is within. Default is False.
@@ -216,14 +242,23 @@ def shapes_to_masks(shapes: gpd.GeoDataFrame | list[gpd.GeoDataFrame], target, r
         A list of masks where points inside each geometry are 1, and those outside are xp.nan
 
     """
+    mask_dim_index = None
     if isinstance(shapes, gpd.GeoDataFrame):
+        mask_dim_index = get_mask_dim_index(mask_dim, shapes)
         shapes = _geopandas_to_shape_list(shapes)
     if regular:
         mask_function = rasterize
     else:
         mask_function = mask_contains_points
 
-    return [mask_function([shape], target.coords, **kwargs) for shape in shapes]
+    masks = [mask_function([shape], target.coords, **kwargs) for shape in shapes]
+    if mask_dim_index is None:
+        return masks
+
+    return [
+        mask.assign_coords({mask_dim_index.name: label}).assign_attrs({_MASK_DIM_ATTR: mask_dim_index.name})
+        for mask, label in zip(masks, mask_dim_index)
+    ]
 
 
 def shapes_to_mask(shapes, target, regular=True, **kwargs):
@@ -520,10 +555,13 @@ def reduce(
     assert not (geodataframe is not None and mask_arrays is not None), (
         "Either a geodataframe or mask arrays must be provided, not both"
     )
+    _mask_arrays: list[xr.DataArray] | None
     if mask_arrays is not None:
-        _mask_arrays: list[xr.DataArray] | None = ensure_list(mask_arrays)
+        _mask_arrays = ensure_list(mask_arrays)
+        precomputed_mask_dim_index = _mask_arrays_dim_index(_mask_arrays)
     else:
         _mask_arrays = None
+        precomputed_mask_dim_index = None
 
     if isinstance(dataarray, xr.Dataset):
         return_as: str = kwargs.pop("return_as", "xarray")
@@ -531,7 +569,11 @@ def reduce(
             out_ds = xr.Dataset().assign_attrs(dataarray.attrs)
             for var in dataarray.data_vars:
                 out_da = _reduce_dataarray_as_xarray(
-                    dataarray[var], geodataframe=geodataframe, mask_arrays=_mask_arrays, **kwargs
+                    dataarray[var],
+                    geodataframe=geodataframe,
+                    mask_arrays=_mask_arrays,
+                    precomputed_mask_dim_index=precomputed_mask_dim_index,
+                    **kwargs,
                 )
                 out_ds[out_da.name] = out_da
             return out_ds
@@ -552,13 +594,20 @@ def reduce(
         else:
             raise TypeError("Return as type not recognised or incompatible with inputs")
     else:
-        return _reduce_dataarray_as_xarray(dataarray, geodataframe=geodataframe, mask_arrays=_mask_arrays, **kwargs)
+        return _reduce_dataarray_as_xarray(
+            dataarray,
+            geodataframe=geodataframe,
+            mask_arrays=_mask_arrays,
+            precomputed_mask_dim_index=precomputed_mask_dim_index,
+            **kwargs,
+        )
 
 
 def _reduce_dataarray_as_xarray(
     dataarray: xr.DataArray,
     geodataframe: gpd.GeoDataFrame | None = None,
     mask_arrays: list[xr.DataArray] | None = None,
+    precomputed_mask_dim_index: pd.Index | None = None,
     how: T.Callable | str = "mean",
     weights: None | str | ndarray = None,
     lat_key: str | None = None,
@@ -709,9 +758,12 @@ def _reduce_dataarray_as_xarray(
 
     # If no geodataframe, there is just one reduced array
     if geodataframe is not None:
-        mask_dim_index = get_mask_dim_index(mask_dim, geodataframe)
-        out_xr = xr.concat(reduced_list, dim=mask_dim_index.name)
-        out_xr = out_xr.assign_coords({mask_dim_index.name: mask_dim_index})
+        geometry_mask_dim_index = get_mask_dim_index(mask_dim, geodataframe)
+        out_xr = xr.concat(reduced_list, dim=geometry_mask_dim_index.name)
+        out_xr = out_xr.assign_coords({geometry_mask_dim_index.name: geometry_mask_dim_index})
+    elif precomputed_mask_dim_index is not None:
+        out_xr = xr.concat(reduced_list, dim=precomputed_mask_dim_index.name)
+        out_xr = out_xr.assign_coords({precomputed_mask_dim_index.name: precomputed_mask_dim_index})
     elif mask_dim is None and len(reduced_list) == 1:
         out_xr = reduced_list[0]
     else:
@@ -722,7 +774,7 @@ def _reduce_dataarray_as_xarray(
     if geodataframe is not None:
         if return_geometry_as_coord:
             out_xr = out_xr.assign_coords(
-                **{"geometry": (mask_dim_index.name, [_g for _g in geodataframe["geometry"]])}
+                **{"geometry": (geometry_mask_dim_index.name, [_g for _g in geodataframe["geometry"]])}
             )
         out_xr = out_xr.assign_attrs({**geodataframe.attrs, **extra_out_attrs})
 

--- a/tests/test_30_spatial.py
+++ b/tests/test_30_spatial.py
@@ -497,6 +497,20 @@ def test_shapes_to_masks_geodataframe():
     assert len(result) == len(gdf)
 
 
+def test_shapes_to_masks_labels_are_used_by_reduce():
+    """Masks built from a GeoDataFrame retain its labels during reduction."""
+    from earthkit.transforms.spatial import shapes_to_masks
+
+    gdf = gpd.GeoDataFrame({"geometry": [_BOX_A, _BOX_B], "region": ["north", "south"]})
+    masks = shapes_to_masks(gdf, _MCP_DA, regular=False, mask_dim="region", lat_key="latitude", lon_key="longitude")
+
+    direct = spatial.reduce(_MCP_DA, gdf, mask_dim="region", lat_key="latitude", lon_key="longitude")
+    precomputed = spatial.reduce(_MCP_DA, mask_arrays=masks, lat_key="latitude", lon_key="longitude")
+
+    assert list(precomputed["region"].values) == ["north", "south"]
+    xr.testing.assert_equal(precomputed, direct)
+
+
 @pytest.mark.skipif(not rasterio_available, reason="rasterio is not available")
 def test_shapes_to_mask_regular_grid():
     """shapes_to_mask with regular=True (rasterize path) returns a 2-D mask."""
@@ -520,6 +534,19 @@ def test_shapes_to_masks_regular_grid():
     assert len(result) == 1
     assert isinstance(result[0], xr.DataArray)
     assert set(result[0].dims) == {"lat", "lon"}
+
+
+@pytest.mark.skipif(not rasterio_available, reason="rasterio is not available")
+def test_shapes_to_masks_all_touched():
+    """all_touched changes the cells included by a reusable regular-grid mask."""
+    shape = Polygon([(0.25, 0.25), (0.25, 0.75), (0.75, 0.75), (0.75, 0.25)])
+    gdf = gpd.GeoDataFrame(geometry=[shape])
+
+    center_masks = spatial.shapes_to_masks(gdf, _REG_DA, all_touched=False)
+    touched_masks = spatial.shapes_to_masks(gdf, _REG_DA, all_touched=True)
+
+    assert np.count_nonzero(center_masks[0]) == 0
+    assert np.count_nonzero(touched_masks[0]) == 4
 
 
 # ---------------------------------------------------------------------------
@@ -965,6 +992,26 @@ def test_spatial_reduce_precomputed_mask_irr_list_two_masks(convention):
     result = spatial.reduce(_MCP_DA, mask_arrays=[mask_a, mask_b], how="mean", lat_key="latitude", lon_key="longitude")
     np.testing.assert_allclose(result.isel(index=0).item(), 3.0)
     np.testing.assert_allclose(result.isel(index=1).item(), 1.0)
+
+
+def test_reusable_masks_reduce_multiple_variables_and_dates():
+    """One mask set can be used for a Dataset containing several dates and variables."""
+    gdf = gpd.GeoDataFrame({"geometry": [_BOX_A, _BOX_B], "region": ["north", "south"]})
+    masks = spatial.shapes_to_masks(
+        gdf, _MCP_DA, regular=False, mask_dim="region", lat_key="latitude", lon_key="longitude"
+    )
+    data = xr.Dataset(
+        {
+            "temperature": xr.concat([_MCP_DA, _MCP_DA + 10], dim=pd.Index([1, 2], name="date")),
+            "rainfall": xr.concat([_MCP_DA + 100, _MCP_DA + 110], dim=pd.Index([1, 2], name="date")),
+        }
+    )
+
+    result = spatial.reduce(data, mask_arrays=masks, lat_key="latitude", lon_key="longitude")
+
+    assert list(result["region"].values) == ["north", "south"]
+    np.testing.assert_allclose(result["temperature"].sel(region="north"), [3.0, 13.0])
+    np.testing.assert_allclose(result["rainfall"].sel(region="south"), [101.0, 111.0])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Description

Expose `earthkit.transforms.spatial.shapes_to_masks` as a supported API for rasterizing reusable polygon masks. Masks made from a GeoDataFrame retain its index or `mask_dim` labels when supplied to `spatial.reduce(..., mask_arrays=...)`. Existing unlabelled precomputed mask arrays and lists retain their current behavior.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.